### PR TITLE
refac(common): wrap onboard api into stateful class

### DIFF
--- a/src/common/context/ConnectionContext.tsx
+++ b/src/common/context/ConnectionContext.tsx
@@ -1,197 +1,41 @@
-import { createContext, useReducer, Dispatch, FC } from "react";
+import { createContext, useEffect, useState, FC } from "react";
 import { ethers } from "ethers";
-import { API as OnboardApi } from "bnc-onboard/dist/src/interfaces";
-import createOnboardInstance from "common/utils/createOnboardInstance";
-import { Subscriptions } from "bnc-onboard/dist/src/interfaces";
+import Onboard from "bnc-onboard";
+import {OnboardWrapper, ConnectionState, DefaultState} from 'common/utils/createOnboardInstance'
 
-type Provider = ethers.providers.Web3Provider;
-type Address = string;
-type Network = ethers.providers.Network;
-type Signer = ethers.Signer;
-
-type ConnectionState = {
-  provider: Provider | null;
-  onboard: OnboardApi | null;
-  signer: Signer | null;
-  network: Network | null;
-  address: Address | null;
-  error: Error | null;
-  isConnected: boolean;
-};
-
-const SET_PROVIDER = "SET_PROVIDER";
-const SET_ONBOARD = "SET_ONBOARD";
-const SET_SIGNER = "SET_SIGNER";
-const SET_NETWORK = "SET_NETWORK";
-const SET_ADDRESS = "SET_ADDRESS";
-const SET_ERROR = "SET_ERROR";
-const SET_CONNECTION_STATUS = "SET_CONNECTION_STATUS";
-const RESET_STATE = "RESET_STATE";
-
-export const actions = {
-  SET_PROVIDER: SET_PROVIDER as typeof SET_PROVIDER,
-  SET_ONBOARD: SET_ONBOARD as typeof SET_ONBOARD,
-  SET_SIGNER: SET_SIGNER as typeof SET_SIGNER,
-  SET_NETWORK: SET_NETWORK as typeof SET_NETWORK,
-  SET_ADDRESS: SET_ADDRESS as typeof SET_ADDRESS,
-  SET_ERROR: SET_ERROR as typeof SET_ERROR,
-  SET_CONNECTION_STATUS: SET_CONNECTION_STATUS as typeof SET_CONNECTION_STATUS,
-  RESET_STATE: RESET_STATE as typeof RESET_STATE,
-};
-
-type Action =
-  | {
-      type: `${typeof SET_PROVIDER}`;
-      payload: Provider | null;
-    }
-  | {
-      type: typeof SET_ONBOARD;
-      payload: OnboardApi | null;
-    }
-  | {
-      type: typeof SET_SIGNER;
-      payload: Signer | null;
-    }
-  | {
-      type: typeof SET_NETWORK;
-      payload: Network | null;
-    }
-  | {
-      type: typeof SET_ADDRESS;
-      payload: Address | null;
-    }
-  | {
-      type: typeof SET_ERROR;
-      payload: Error | null;
-    }
-  | {
-      type: typeof SET_CONNECTION_STATUS;
-      payload: boolean;
-    }
-  | { type: typeof RESET_STATE };
-
-export type ConnectionDispatch = Dispatch<Action>;
+export const EMPTY: unique symbol = Symbol();
 
 type WithDelegatedProps = {
   [k: string]: unknown;
 };
 
-export const EMPTY: unique symbol = Symbol();
+type TConnectionContext = [
+  ConnectionState,
+  any | null,
+];
 
 export const ConnectionContext = createContext<
   TConnectionContext | typeof EMPTY
 >(EMPTY);
 ConnectionContext.displayName = "ConnectionContext";
 
-function connectionReducer(state: ConnectionState, action: Action) {
-  switch (action.type) {
-    case SET_PROVIDER: {
-      return {
-        ...state,
-        provider: action.payload,
-      };
-    }
-    case SET_ONBOARD: {
-      return {
-        ...state,
-        onboard: action.payload,
-      };
-    }
-    case SET_SIGNER: {
-      return {
-        ...state,
-        signer: action.payload,
-      };
-    }
-    case SET_NETWORK: {
-      return {
-        ...state,
-        network: action.payload,
-      };
-    }
-    case SET_ADDRESS: {
-      return {
-        ...state,
-        address: action.payload,
-      };
-    }
-    case SET_ERROR: {
-      return {
-        ...state,
-        error: action.payload,
-      };
-    }
-    case SET_CONNECTION_STATUS: {
-      return {
-        ...state,
-        isConnected: action.payload,
-      };
-    }
-    case RESET_STATE: {
-      return INITIAL_STATE;
-    }
-    default: {
-      throw new Error(`Unsupported action type ${(action as any).type}`);
-    }
-  }
-}
-
-const INITIAL_STATE = {
-  provider: null,
-  onboard: null,
-  signer: null,
-  network: null,
-  address: null,
-  error: null,
-  isConnected: false,
-};
-
-const connect = async (
-  dispatch: ConnectionDispatch,
-  network: Network | null,
-  subscriptions: Subscriptions
-) => {
-  try {
-    const onboardInstance = createOnboardInstance(network, subscriptions);
-
-    await onboardInstance.walletSelect();
-    await onboardInstance.walletCheck();
-
-    dispatch({ type: actions.SET_ONBOARD, payload: onboardInstance });
-    dispatch({ type: actions.SET_CONNECTION_STATUS, payload: true });
-  } catch (error) {
-    dispatch({ type: actions.SET_ERROR, payload: error });
-  }
-};
-
-const disconnect = (
-  dispatch: ConnectionDispatch,
-  isConnected: boolean,
-  onboard: OnboardApi | null
-) => {
-  if (!isConnected) {
-    return;
-  }
-  onboard?.walletReset();
-  dispatch({ type: actions.RESET_STATE });
-};
-
-type TConnectionContext = [
-  ConnectionState,
-  ConnectionDispatch,
-  typeof connect,
-  typeof disconnect
-];
 
 export const ConnectionProvider: FC<WithDelegatedProps> = ({
   children,
   ...delegated
 }) => {
-  const [state, dispatch] = useReducer(connectionReducer, INITIAL_STATE);
+  const [state, setState] = useState<ConnectionState>(DefaultState)
+  const [api, setApi] = useState<any>(null)
+
+  useEffect(()=>{
+    // we can imagine other providers with a similar API: combination of event emitter for state, and API calls
+    setApi(OnboardWrapper(state,{ethers,Onboard},setState))
+  },[])
+
 
   return (
     <ConnectionContext.Provider
-      value={[state, dispatch, connect, disconnect]}
+      value={[state, api]}
       {...delegated}
     >
       {children}

--- a/src/common/hooks/useConnection.ts
+++ b/src/common/hooks/useConnection.ts
@@ -1,78 +1,16 @@
-import { useContext, useEffect } from "react";
+import { useContext } from "react";
 import {
   ConnectionContext,
   EMPTY,
-  actions,
 } from "common/context/ConnectionContext";
-import { ethers } from "ethers";
-import { Wallet } from "bnc-onboard/dist/src/interfaces";
-import { SUPPORTED_NETWORK_IDS } from "common/config";
 
+
+// this hook could go away and view uses useContext(ConnectionContext)
 export function useConnection() {
   const context = useContext(ConnectionContext);
   if (context === EMPTY) {
     throw new Error(`UseConnection must be used within a Connection Provider.`);
   }
-  const [
-    { provider, onboard, signer, network, address, error, isConnected },
-    dispatch,
-    connect,
-    disconnect,
-  ] = context;
-
-  // When network changes, reconnect
-  useEffect(() => {
-    // These are optional callbacks to be passed into onboard.
-    const subscriptions = {
-      address: (address: string | null) => {
-        dispatch({ type: actions.SET_ADDRESS, payload: address });
-      },
-      network: async (networkId: any) => {
-        if (!SUPPORTED_NETWORK_IDS.includes(networkId) && networkId != null) {
-          throw new Error(
-            "This dApp will work only with the Mainnet or Kovan network"
-          );
-        }
-        onboard?.config({ networkId: networkId });
-      },
-      wallet: async (wallet: Wallet) => {
-        if (wallet.provider) {
-          const ethersProvider = new ethers.providers.Web3Provider(
-            wallet.provider
-          );
-          dispatch({ type: actions.SET_PROVIDER, payload: ethersProvider });
-          dispatch({
-            type: actions.SET_SIGNER,
-            payload: ethersProvider.getSigner(),
-          });
-          dispatch({
-            type: actions.SET_NETWORK,
-            payload: await ethersProvider.getNetwork(),
-          });
-        } else {
-          dispatch({ type: actions.SET_PROVIDER, payload: null });
-          dispatch({ type: actions.SET_NETWORK, payload: null });
-        }
-      },
-    };
-
-    connect(dispatch, network, subscriptions);
-  }, [network]);
-
-  // Disconnect and reset state on change;
-  useEffect(() => {
-    disconnect(dispatch, isConnected, onboard);
-  }, [isConnected, onboard]);
-
-  return {
-    provider,
-    onboard,
-    signer,
-    network,
-    address,
-    error,
-    isConnected,
-    connect,
-    disconnect,
-  };
+  // returns [state,{connect,disconnect, get, set}]
+  return context
 }

--- a/src/common/utils/createOnboardInstance.ts
+++ b/src/common/utils/createOnboardInstance.ts
@@ -1,8 +1,8 @@
 import Onboard from "bnc-onboard";
+import assert from 'assert'
 import config from "common/config";
 import { ethers } from "ethers";
-import { Initialization, Subscriptions } from "bnc-onboard/dist/src/interfaces";
-type Network = ethers.providers.Network;
+import { Initialization, Subscriptions,  API as OnboardApi, Wallet } from "bnc-onboard/dist/src/interfaces";
 
 // Other options that could be added to this instance, from docs.
 // interface Initialization {
@@ -36,4 +36,90 @@ export default function createOnboardInstance(
   };
 
   return Onboard(onboardConfig);
+}
+
+type Provider = ethers.providers.Web3Provider;
+type Address = string;
+type Network = ethers.providers.Network;
+type Signer = ethers.Signer;
+export type ConnectionState = {
+  provider: Provider | null;
+  onboard: OnboardApi | null;
+  signer: Signer | null;
+  network: Network | null;
+  address: Address | null;
+  error: Error | null;
+  isConnected: boolean;
+};
+export const DefaultState: ConnectionState = {
+  provider: null,
+  onboard: null,
+  signer: null,
+  network: null,
+  address: null,
+  error: null,
+  isConnected: false,
+}
+
+// This looks like it can execute in any environment, but the quirk about onboard is 
+// it must be run in a browser afaik
+
+// allows you to set initial state, pass in dependencies and emit events
+export const OnboardWrapper = (state={...DefaultState},{Onboard,ethers}:any, emit:(state:any)=>void) => {
+  let onboard:OnboardApi | null = null
+  // helper to set state internally and emit out
+  function set(obj={}){
+    state = {...DefaultState,...state, ...obj}
+    emit(state)
+  }
+  // gets state
+  function get(){
+    return state
+  }
+  // hard coded subscription callbacks
+  const subscriptions = {
+    address: (address: string | null) => {
+      set({address})
+    },
+    network: async (networkId: any) => {
+      onboard?.config({ networkId: networkId });
+    },
+    wallet: async (wallet: Wallet) => {
+      if (wallet.provider) {
+        // we should probably wrap this with ethers elsewhere
+        const ethersProvider = new ethers.providers.Web3Provider(
+          wallet.provider
+        );
+        set({
+          provider:ethersProvider,
+          signer:await ethersProvider.getSigner(),
+          network:await ethersProvider.getNetwork()
+        })
+      } else {
+        set({
+          provider:null,network:null,signer:null
+        })
+      }
+    },
+  };
+  async function connect(network:Network){
+    assert(!(state?.isConnected),'Already connected')
+    onboard = Onboard({subscriptions,network})
+    assert(onboard,'Onboard instance null')
+    await onboard.walletSelect();
+    await onboard.walletCheck();
+    set({onboard,isConnected:true})
+  }
+  function disconnect(){
+    assert(state?.isConnected,'Already disconnected')
+    onboard?.walletReset();
+    set(DefaultState)
+  }
+  // fill in default state on init and emit event
+  set(state)
+
+  // return api interface
+  return {
+    connect,disconnect,set,get
+  }
 }


### PR DESCRIPTION
experiment to see how we could break onboard out into its own class and have a common api for stateful classes in the form of:
```
  const Class = (initialState | config, depedencies:any, emitter: (state)=>void) => api:any

```
  which is easily consumed by a context or hook. 