### PR TITLE
fix: clear keys on account switch, decode only newest commits

### DIFF
--- a/src/features/vote/CommitPhase.tsx
+++ b/src/features/vote/CommitPhase.tsx
@@ -180,13 +180,13 @@ const ActiveRequestsForm: FC<Props> = ({
     }
     if (activeRequests.length && encryptedVotes.length) {
       const tv = [] as TableValue[];
+      // I believe latest events are on bottom. requires testing.
+      const latestVotesFirst = [...encryptedVotes].reverse();
       activeRequests.forEach((el) => {
         const datum = {} as TableValue;
         datum.ancillaryData = el.ancillaryData;
         datum.identifier = el.identifier;
         let vote = "-";
-        // I believe latest events are on bottom. requires testing.
-        const latestVotesFirst = [...encryptedVotes].reverse();
         const findVote = latestVotesFirst.find(
           (x) =>
             x.identifier === el.identifier &&

--- a/src/features/vote/Vote.tsx
+++ b/src/features/vote/Vote.tsx
@@ -84,6 +84,12 @@ const Vote = () => {
     }
   }, [state.signer]);
 
+  useEffect(()=>{
+    // address changed, remove these keys
+    setPrivateKey("");
+    setPublicKey("");
+  },[state.address])
+
   useEffect(() => {
     if (priceRequestsAdded.length) {
       const filtered = priceRequestsAdded.filter((el) => {

--- a/src/hooks/useEncryptedVotesEvents.ts
+++ b/src/hooks/useEncryptedVotesEvents.ts
@@ -12,7 +12,8 @@ export default function useEncryptedVotesEvents(
   roundId: string
 ) {
   const { data, error, isFetching, refetch } = useQuery<EncryptedVote[]>(
-    "encryptedVotesEvents",
+    // key encryped votes by connected address
+    ["encryptedVotesEvents",address],
     () => {
       return queryEncryptedVotes(
         contract,
@@ -28,7 +29,10 @@ export default function useEncryptedVotesEvents(
         }
       });
     },
-    { enabled: contract !== null && privateKey !== "" }
+    { 
+      // do not run query if any of these are null
+      enabled: contract !== null && privateKey !== "" && address != null, 
+    }
   );
 
   if (data) {

--- a/src/web3/types.web3.ts
+++ b/src/web3/types.web3.ts
@@ -23,3 +23,4 @@ export interface PendingRequestAncillary {
   // hexstring
   ancillaryData: string;
 }
+


### PR DESCRIPTION
This has 3 fixes:
1. clears private/public keys when new accounts are detected
2. ensures react query does not cache encrypted data between accounts
3. de-duplicates commit events to ensure only the latest events get decrypted