### PR TITLE
Wallet two key select fixes

### DIFF
--- a/src/common/components/text-input/TextInput.tsx
+++ b/src/common/components/text-input/TextInput.tsx
@@ -40,7 +40,7 @@ const _TextInput: ForwardRefRenderFunction<HTMLInputElement, Props> = (
 const TextInput = forwardRef(_TextInput);
 TextInput.displayName = "Modal";
 
-const StyledInput = styled.div`
+export const StyledInput = styled.div`
   display: flex;
   flex-direction: column;
   .label {

--- a/src/features/wallet/TwoKeyContractModal.tsx
+++ b/src/features/wallet/TwoKeyContractModal.tsx
@@ -41,12 +41,13 @@ const _TwoKeyContractModal: ForwardRefRenderFunction<
   const [showForm, setShowForm] = useState(false);
   const [value, setValue] = useState("");
   const [error, setError] = useState("");
-
+  const [success, setSuccess] = useState(false);
   const closeForm = useCallback(() => {
     if (showForm) {
       setShowForm(false);
       setValue("");
     } else {
+      setSuccess(false);
       setShowForm(true);
     }
   }, [showForm]);
@@ -59,14 +60,21 @@ const _TwoKeyContractModal: ForwardRefRenderFunction<
       return createDesignatedVotingContract(value, signer, network).then(
         (res) => {
           console.log("Success dvc?", res);
-          setValue("");
-          setError("");
+          closeForm();
+          setSuccess(true);
         }
       );
     }
-  }, [value, network, signer]);
+  }, [value, network, signer, closeForm]);
   return (
-    <Modal isOpen={isOpen} onClose={close} ref={externalRef}>
+    <Modal
+      isOpen={isOpen}
+      onClose={() => {
+        close();
+        setSuccess(false);
+      }}
+      ref={externalRef}
+    >
       <ModalWrapper>
         <h3 className="header">Two Key Voting</h3>
         {!isConnected ? (
@@ -103,6 +111,7 @@ const _TwoKeyContractModal: ForwardRefRenderFunction<
             </div>
           </>
         )}
+        {success ? <div>Successfully added two-key contract.</div> : null}
         {showForm ? (
           <FormWrapper>
             <StyledInput>

--- a/src/features/wallet/TwoKeyContractModal.tsx
+++ b/src/features/wallet/TwoKeyContractModal.tsx
@@ -104,7 +104,7 @@ const _TwoKeyContractModal: ForwardRefRenderFunction<
                     className="open-form"
                     tw="flex-grow text-right"
                   >
-                    Add Cold Wallet Address
+                    {showForm ? "Remove" : "Add Cold Wallet Address"}
                   </div>
                 </>
               ) : (

--- a/src/features/wallet/TwoKeyContractModal.tsx
+++ b/src/features/wallet/TwoKeyContractModal.tsx
@@ -53,17 +53,21 @@ const _TwoKeyContractModal: ForwardRefRenderFunction<
   }, [showForm]);
 
   const submitForm = useCallback(() => {
+    // console.log(ethers.utils.isAddress(value));
+
     if (value.substr(0, 2).toLowerCase() !== "0x")
       return setError("Address must start with 0x");
     if (value.length !== 42) return setError("Address must be 42 characters");
+
     if (value && network && signer) {
-      return createDesignatedVotingContract(value, signer, network).then(
-        (res) => {
-          console.log("Success dvc?", res);
+      return createDesignatedVotingContract(value, signer, network)
+        .then((res) => {
           closeForm();
           setSuccess(true);
-        }
-      );
+        })
+        .catch((err) => {
+          console.log("err in two key contract creation", err);
+        });
     }
   }, [value, network, signer, closeForm]);
   return (
@@ -111,7 +115,7 @@ const _TwoKeyContractModal: ForwardRefRenderFunction<
             </div>
           </>
         )}
-        {success ? <div>Successfully added two-key contract.</div> : null}
+        {success && <div>Successfully added two-key contract.</div>}
         {showForm ? (
           <FormWrapper>
             <StyledInput>

--- a/src/features/wallet/TwoKeyContractModal.tsx
+++ b/src/features/wallet/TwoKeyContractModal.tsx
@@ -133,10 +133,10 @@ const _TwoKeyContractModal: ForwardRefRenderFunction<
             </StyledInput>
 
             <ButtonWrapper>
-              <Button onClick={() => toggleForm()} variant="primary">
+              <Button onClick={toggleForm} variant="primary">
                 Cancel
               </Button>
-              <Button onClick={() => submitForm()} variant="secondary">
+              <Button onClick={submitForm} variant="secondary">
                 Save
               </Button>
             </ButtonWrapper>

--- a/src/features/wallet/TwoKeyContractModal.tsx
+++ b/src/features/wallet/TwoKeyContractModal.tsx
@@ -42,7 +42,7 @@ const _TwoKeyContractModal: ForwardRefRenderFunction<
   const [value, setValue] = useState("");
   const [error, setError] = useState("");
   const [success, setSuccess] = useState(false);
-  const closeForm = useCallback(() => {
+  const toggleForm = useCallback(() => {
     if (showForm) {
       setShowForm(false);
       setValue("");
@@ -53,8 +53,8 @@ const _TwoKeyContractModal: ForwardRefRenderFunction<
   }, [showForm]);
 
   const submitForm = useCallback(() => {
-    // console.log(ethers.utils.isAddress(value));
-
+    // We don't use ethers.utils.isAddress because it allows for a 40 char address
+    // that doesn't include the prefix -- it will return true, which is not desired behaviour.
     if (value.substr(0, 2).toLowerCase() !== "0x")
       return setError("Address must start with 0x");
     if (value.length !== 42) return setError("Address must be 42 characters");
@@ -62,14 +62,14 @@ const _TwoKeyContractModal: ForwardRefRenderFunction<
     if (value && network && signer) {
       return createDesignatedVotingContract(value, signer, network)
         .then((res) => {
-          closeForm();
+          toggleForm();
           setSuccess(true);
         })
         .catch((err) => {
           console.log("err in two key contract creation", err);
         });
     }
-  }, [value, network, signer, closeForm]);
+  }, [value, network, signer, toggleForm]);
   return (
     <Modal
       isOpen={isOpen}
@@ -100,9 +100,7 @@ const _TwoKeyContractModal: ForwardRefRenderFunction<
                 <>
                   <Disconnected tw="flex-grow">Not Connected</Disconnected>
                   <div
-                    onClick={() => {
-                      closeForm();
-                    }}
+                    onClick={toggleForm}
                     className="open-form"
                     tw="flex-grow text-right"
                   >
@@ -135,7 +133,7 @@ const _TwoKeyContractModal: ForwardRefRenderFunction<
             </StyledInput>
 
             <ButtonWrapper>
-              <Button onClick={() => closeForm()} variant="primary">
+              <Button onClick={() => toggleForm()} variant="primary">
                 Cancel
               </Button>
               <Button onClick={() => submitForm()} variant="secondary">

--- a/src/features/wallet/styled/TwoKeyContractModal.styled.tsx
+++ b/src/features/wallet/styled/TwoKeyContractModal.styled.tsx
@@ -35,3 +35,26 @@ export const ModalWrapper = styled.div`
     }
   }
 `;
+
+export const FormWrapper = styled.div`
+  margin-top: 1rem;
+`;
+
+export const ButtonWrapper = styled.div`
+  text-align: center;
+  button {
+    &:first-of-type {
+      margin-right: 0.4rem;
+    }
+    &:nth-of-type(2) {
+      margin-left: 0.4rem;
+    }
+    width: 157px;
+  }
+`;
+
+export const Error = styled.span`
+  color: #ff4a4a;
+  margin: 1rem 0;
+  font-size: 0.75rem;
+`;


### PR DESCRIPTION
**Motivation**

Add in cold wallet address input.
**Summary**

Add in the cold wallet address input. 3rd wallet is required for two key contract for withdrawal. Previously it was the msg.sender, which although works, is not the intention of the two key contract.


**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested