### PR TITLE
feat: events propagate errors to context; direct reward retrieve for single round;  total rewards can be read from old contracts

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@uma/core-1-2-2": "npm:@uma/core@1.2.2",
     "axios": "^0.21.1",
     "babel-plugin-macros": "^3.0.1",
+    "bnc-notify": "^1.6.1",
     "bnc-onboard": "^1.20.0",
     "contentful": "^8.3.5",
     "downshift": "^6.1.3",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@uma/core": "2.2.0-alpha.0",
+    "@uma/core-1-2-2": "npm:@uma/core@1.2.2",
     "axios": "^0.21.1",
     "babel-plugin-macros": "^3.0.1",
     "bnc-onboard": "^1.20.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,7 +49,8 @@ function App(props: Props) {
             });
           })
           .catch((err) => {
-            addError("Sign failed.");
+            const error = new Error("Sign failed.");
+            addError(error);
           });
       }
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,7 +80,6 @@ function App(props: Props) {
       state.network &&
       state.network.chainId !== previousNetwork.chainId
     ) {
-      console.log("did we make it");
       window.location.reload();
     }
   }, [state.network, previousNetwork]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,6 +69,22 @@ function App(props: Props) {
     }
   }, [state.isConnected, state.address, props.queryClient]);
 
+  // Do a hard refresh if the user changes networks (IE: mainnet to kovan).
+  // Cleaner overall, as the app can error out with network changes.
+  // Not a big deal as in production this app is only supported on mainnet anyway.
+  const previousNetwork = usePrevious(state.network);
+
+  useEffect(() => {
+    if (
+      previousNetwork &&
+      state.network &&
+      state.network.chainId !== previousNetwork.chainId
+    ) {
+      console.log("did we make it");
+      window.location.reload();
+    }
+  }, [state.network, previousNetwork]);
+
   // Disconnect user if they are looged in and they switch accounts in MM
   const previousAddress = usePrevious(state.address);
   useEffect(() => {

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -26,6 +26,13 @@ export const COIN_GECKO_UMA_TICKER_DATA = {
   url: "https://api.coingecko.com/api/v3/coins/uma",
 };
 
+// We need these for rewards.
+export const OLD_VOTING_CONTRACT_ADDRESSES = [
+  "0xFe3C4F1ec9f5df918D42Ef7Ed3fBA81CC0086c5F",
+  "0x9921810C710E7c3f7A7C6831e30929f19537a545",
+  "0x1d847fb6e04437151736a53f09b6e49713a52aad",
+];
+
 export default function config(network: Network | null) {
   const infuraRpc = `https://${
     network ? network?.name : "mainnet"

--- a/src/common/context/ErrorContext.tsx
+++ b/src/common/context/ErrorContext.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, createContext, FC, ReactNode } from "react";
 
 interface ContextProps {
   error: string | undefined;
-  addError: (message: string) => void;
+  addError: (message: Error) => void;
   removeError: () => void;
 }
 
@@ -21,11 +21,11 @@ const ErrorProvider: FC<ProviderProps> = ({ children }) => {
 
   const removeError = () => setError(undefined);
 
-  const addError = (message: string | undefined) => setError(message);
+  const addError = (error: Error | undefined) => setError(error?.message);
 
   const contextValue: ContextProps = {
     error,
-    addError: useCallback((message) => addError(message), []),
+    addError: useCallback((error) => addError(error), []),
     removeError: useCallback(() => removeError(), []),
   };
 

--- a/src/common/context/OnboardContext.tsx
+++ b/src/common/context/OnboardContext.tsx
@@ -3,6 +3,7 @@ import { ethers } from "ethers";
 import { API as OnboardApi } from "bnc-onboard/dist/src/interfaces";
 import createOnboardInstance from "common/utils/web3/createOnboardInstance";
 import { Subscriptions } from "bnc-onboard/dist/src/interfaces";
+import { API as NotifyAPI } from "bnc-notify";
 
 type Provider = ethers.providers.Web3Provider;
 type Address = string;
@@ -17,6 +18,7 @@ type OnboardState = {
   address: Address | null;
   error: Error | null;
   isConnected: boolean;
+  notify: NotifyAPI | null;
 };
 
 const SET_PROVIDER = "SET_PROVIDER";
@@ -27,6 +29,7 @@ const SET_ADDRESS = "SET_ADDRESS";
 const SET_ERROR = "SET_ERROR";
 const SET_CONNECTION_STATUS = "SET_CONNECTION_STATUS";
 const RESET_STATE = "RESET_STATE";
+const SET_NOTIFY = "SET_NOTIFY";
 
 export const actions = {
   SET_PROVIDER: SET_PROVIDER as typeof SET_PROVIDER,
@@ -37,6 +40,7 @@ export const actions = {
   SET_ERROR: SET_ERROR as typeof SET_ERROR,
   SET_CONNECTION_STATUS: SET_CONNECTION_STATUS as typeof SET_CONNECTION_STATUS,
   RESET_STATE: RESET_STATE as typeof RESET_STATE,
+  SET_NOTIFY: SET_NOTIFY as typeof SET_NOTIFY,
 };
 
 type Action =
@@ -68,7 +72,8 @@ type Action =
       type: typeof SET_CONNECTION_STATUS;
       payload: boolean;
     }
-  | { type: typeof RESET_STATE };
+  | { type: typeof RESET_STATE }
+  | { type: typeof SET_NOTIFY; payload: NotifyAPI | null };
 
 export type OnboardDispatch = Dispatch<Action>;
 
@@ -119,6 +124,12 @@ function connectionReducer(state: OnboardState, action: Action) {
         isConnected: action.payload,
       };
     }
+    case SET_NOTIFY: {
+      return {
+        ...state,
+        notify: action.payload,
+      };
+    }
     case RESET_STATE: {
       return INITIAL_STATE;
     }
@@ -136,6 +147,7 @@ const INITIAL_STATE = {
   address: null,
   error: null,
   isConnected: false,
+  notify: null,
 };
 
 const connect = async (

--- a/src/common/hooks/useOnboard.ts
+++ b/src/common/hooks/useOnboard.ts
@@ -60,13 +60,24 @@ export default function useOnboard() {
             },
           });
 
-          dispatch({
-            type: actions.SET_NOTIFY,
-            payload: Notify({
-              dappId: process.env.REACT_APP_PUBLIC_ONBOARD_API_KEY, // [String] The API key created by step one above
-              networkId, // [Integer] The Ethereum network ID your Dapp uses.
-            }),
-          });
+          // if (process.env.REACT_APP_CURRENT_ENV !== "test") {
+          if (networkId) {
+            dispatch({
+              type: actions.SET_NOTIFY,
+              payload: Notify({
+                dappId: process.env.REACT_APP_PUBLIC_ONBOARD_API_KEY, // [String] The API key created by step one above
+                networkId, // [Integer] The Ethereum network ID your Dapp uses.
+                desktopPosition: "topRight",
+              }),
+            });
+          } else {
+            dispatch({
+              type: actions.SET_NOTIFY,
+              payload: null,
+            });
+          }
+
+          // }
         },
         wallet: async (wallet: Wallet) => {
           if (wallet.provider) {

--- a/src/common/hooks/useOnboard.ts
+++ b/src/common/hooks/useOnboard.ts
@@ -2,6 +2,7 @@ import { useContext, useEffect, useState } from "react";
 import { OnboardContext, actions } from "common/context/OnboardContext";
 import { ethers } from "ethers";
 import { Wallet } from "bnc-onboard/dist/src/interfaces";
+import Notify from "bnc-notify";
 
 type ChainId = 1 | 42 | 1337;
 
@@ -27,7 +28,16 @@ export default function useOnboard() {
   }
 
   const {
-    state: { provider, onboard, signer, network, address, error, isConnected },
+    state: {
+      provider,
+      onboard,
+      signer,
+      network,
+      address,
+      error,
+      isConnected,
+      notify,
+    },
     dispatch,
     connect,
     disconnect,
@@ -48,6 +58,14 @@ export default function useOnboard() {
               chainId: networkId,
               name: getNetworkName(networkId as ChainId),
             },
+          });
+
+          dispatch({
+            type: actions.SET_NOTIFY,
+            payload: Notify({
+              dappId: process.env.REACT_APP_PUBLIC_ONBOARD_API_KEY, // [String] The API key created by step one above
+              networkId, // [Integer] The Ethereum network ID your Dapp uses.
+            }),
           });
         },
         wallet: async (wallet: Wallet) => {
@@ -96,5 +114,6 @@ export default function useOnboard() {
     disconnect: () => disconnect(dispatch, onboard),
     initOnboard,
     setInitOnboard,
+    notify,
   };
 }

--- a/src/common/hooks/useOnboard.ts
+++ b/src/common/hooks/useOnboard.ts
@@ -60,24 +60,25 @@ export default function useOnboard() {
             },
           });
 
-          // if (process.env.REACT_APP_CURRENT_ENV !== "test") {
-          if (networkId) {
-            dispatch({
-              type: actions.SET_NOTIFY,
-              payload: Notify({
-                dappId: process.env.REACT_APP_PUBLIC_ONBOARD_API_KEY, // [String] The API key created by step one above
-                networkId, // [Integer] The Ethereum network ID your Dapp uses.
-                desktopPosition: "topRight",
-              }),
-            });
-          } else {
-            dispatch({
-              type: actions.SET_NOTIFY,
-              payload: null,
-            });
+          // Notify.js doesn't work on ganache anyway (see: docs).
+          // So don't bother initializing it on test.
+          if (process.env.REACT_APP_CURRENT_ENV !== "test") {
+            if (networkId) {
+              dispatch({
+                type: actions.SET_NOTIFY,
+                payload: Notify({
+                  dappId: process.env.REACT_APP_PUBLIC_ONBOARD_API_KEY, // [String] The API key created by step one above
+                  networkId, // [Integer] The Ethereum network ID your Dapp uses.
+                  desktopPosition: "topRight",
+                }),
+              });
+            } else {
+              dispatch({
+                type: actions.SET_NOTIFY,
+                payload: null,
+              });
+            }
           }
-
-          // }
         },
         wallet: async (wallet: Wallet) => {
           if (wallet.provider) {

--- a/src/common/hooks/useVoteData.ts
+++ b/src/common/hooks/useVoteData.ts
@@ -50,10 +50,8 @@ const POLLING_INTERVAL = 60000;
 // Retrieve vote data per price request from graphQL API.
 // Taken from previous voter-dapp, with heavy refactoring.
 function useVoteData() {
-  const [
-    votingSummaryData,
-    setVotingSummaryData,
-  ] = useState<FormattedPriceRequestRounds>({});
+  const [votingSummaryData, setVotingSummaryData] =
+    useState<FormattedPriceRequestRounds>({});
 
   // Because apollo caches results of queries, we will poll/refresh this query periodically.
   // We set the poll interval to a very slow 60 seconds for now since the vote states
@@ -81,9 +79,7 @@ function useVoteData() {
 
   return {
     votingSummaryData,
-    data: data?.priceRequestRounds
-      ? data.priceRequestRounds
-      : ([] as PriceRequestRound[]),
+    data: data?.priceRequestRounds,
     refetch,
   };
 }

--- a/src/features/vote/ActiveRequests.tsx
+++ b/src/features/vote/ActiveRequests.tsx
@@ -15,6 +15,7 @@ import RevealPhase from "./RevealPhase";
 import ActiveViewDetailsModal from "./ActiveViewDetailsModal";
 import useModal from "common/hooks/useModal";
 import { SigningKeys } from "App";
+import { Round } from "web3/get/queryRounds";
 
 export interface ModalState {
   proposal: string;
@@ -61,7 +62,7 @@ const ActiveRequests: FC<Props> = ({
 
   const { data: votePhase } = useVotePhase();
 
-  const { data: round } = useRound(Number(roundId));
+  const { data: round = {} as Round } = useRound(Number(roundId));
 
   // Set time remaining depending if it's the Commit or Reveal
   // Note: the requests are all slightly differently in there final vote time. I'll use the last
@@ -82,6 +83,7 @@ const ActiveRequests: FC<Props> = ({
       : votingAddress && signingKeys[votingAddress]
       ? signingKeys[votingAddress].publicKey
       : "";
+
   return (
     <Wrapper className="ActiveRequests">
       <div className="header-row" tw="flex items-stretch p-10">

--- a/src/features/vote/ActiveRequests.tsx
+++ b/src/features/vote/ActiveRequests.tsx
@@ -28,6 +28,7 @@ interface Props {
   encryptedVotes: EncryptedVote[];
   refetchEncryptedVotes: Function;
   revealedVotes: VoteRevealed[];
+  refetchVoteRevealedEvents: Function;
   votingAddress: string | null;
   hotAddress: string | null;
   signingKeys: SigningKeys;
@@ -42,6 +43,7 @@ const ActiveRequests: FC<Props> = ({
   refetchEncryptedVotes,
   hotAddress,
   signingKeys,
+  refetchVoteRevealedEvents,
 }) => {
   const [timeRemaining, setTimeRemaining] = useState("00:00");
 
@@ -127,6 +129,7 @@ const ActiveRequests: FC<Props> = ({
           round={round}
           revealedVotes={revealedVotes}
           refetchEncryptedVotes={refetchEncryptedVotes}
+          refetchVoteRevealedEvents={refetchVoteRevealedEvents}
           setViewDetailsModalState={setModalState}
           openViewDetailsModal={open}
         />

--- a/src/features/vote/ActiveRequests.tsx
+++ b/src/features/vote/ActiveRequests.tsx
@@ -75,7 +75,7 @@ const ActiveRequests: FC<Props> = ({
     }, 30000);
 
     return () => clearInterval(timer);
-  }, [activeRequests, votePhase]);
+  }, []);
 
   const signingPublicKey =
     hotAddress && signingKeys[hotAddress]

--- a/src/features/vote/ActiveRequests.tsx
+++ b/src/features/vote/ActiveRequests.tsx
@@ -60,7 +60,7 @@ const ActiveRequests: FC<Props> = ({
     state: { isConnected },
   } = useContext(OnboardContext);
 
-  const { data: votePhase } = useVotePhase();
+  const { data: votePhase = "" } = useVotePhase();
 
   const { data: round = {} as Round } = useRound(Number(roundId));
 

--- a/src/features/vote/CommitPhase.tsx
+++ b/src/features/vote/CommitPhase.tsx
@@ -116,7 +116,10 @@ const CommitPhase: FC<Props> = ({
     (data: FormData) => {
       const validValues = {} as FormData;
       for (let i = 0; i < Object.keys(data).length; i++) {
-        if (Object.values(data)[i] !== "")
+        if (
+          Object.values(data)[i] !== "" &&
+          Object.values(data)[i] !== undefined
+        )
           validValues[Object.keys(data)[i]] = Object.values(data)[i];
       }
 
@@ -256,7 +259,7 @@ const CommitPhase: FC<Props> = ({
                     <div className="select">
                       <RHFDropdown
                         control={control}
-                        name={`${el.identifier}`}
+                        name={`${el.identifier}~${el.unix}~${el.ancHex}`}
                         items={[
                           {
                             value: "",
@@ -277,7 +280,8 @@ const CommitPhase: FC<Props> = ({
                     <TextInput
                       label="Input your vote."
                       control={control}
-                      name={`${el.identifier}~${el.timestamp}~${el.ancHex}`}
+                      name={`${el.identifier}~${el.unix}~${el.ancHex}`}
+
                       placeholder="0.000"
                       variant="text"
                     />

--- a/src/features/vote/CommitPhase.tsx
+++ b/src/features/vote/CommitPhase.tsx
@@ -87,7 +87,7 @@ const CommitPhase: FC<Props> = ({
     revealedVotes
   );
 
-  const { data: roundId } = useCurrentRoundId();
+  const { data: roundId = "" } = useCurrentRoundId();
   const { isOpen, open, close, modalRef } = useModal();
 
   const generateDefaultValues = useCallback(() => {

--- a/src/features/vote/CommitPhase.tsx
+++ b/src/features/vote/CommitPhase.tsx
@@ -281,7 +281,6 @@ const CommitPhase: FC<Props> = ({
                       label="Input your vote."
                       control={control}
                       name={`${el.identifier}~${el.unix}~${el.ancHex}`}
-
                       placeholder="0.000"
                       variant="text"
                     />

--- a/src/features/vote/CommitPhase.tsx
+++ b/src/features/vote/CommitPhase.tsx
@@ -71,7 +71,7 @@ const CommitPhase: FC<Props> = ({
   const [modalState, setModalState] = useState<SubmitModalState>("init");
   const [submitErrorMessage, setSubmitErrorMessage] = useState("");
   const {
-    state: { network, signer },
+    state: { network, signer, notify },
   } = useContext(OnboardContext);
   const { votingContract, designatedVotingContract } = useVotingContract(
     signer,
@@ -93,7 +93,7 @@ const CommitPhase: FC<Props> = ({
   const generateDefaultValues = useCallback(() => {
     const dv = {} as FormData;
     activeRequests.forEach((el) => {
-      dv[el.identifier] = "";
+      dv[`${el.identifier}~${el.time}~${el.ancHex}`] = "";
     });
 
     return dv;
@@ -138,11 +138,15 @@ const CommitPhase: FC<Props> = ({
           if (vc) {
             commitVotes(vc, fd)
               .then((tx) => {
+                // console.log("tx", tx);
                 setModalState("pending");
                 setSubmitErrorMessage("");
+
                 // Need to confirm if the user submits the vote.
                 assert(tx, "Transaction did not get submitted, try again");
                 if (tx) {
+                  if (notify) notify.hash(tx.hash);
+
                   tx.wait(1)
                     .then((conf: any) => {
                       // Temporary, as mining is instant on local ganache.
@@ -175,6 +179,7 @@ const CommitPhase: FC<Props> = ({
       designatedVotingContract,
       votingAddress,
       reset,
+      notify,
     ]
   );
 

--- a/src/features/vote/CommitPhase.tsx
+++ b/src/features/vote/CommitPhase.tsx
@@ -184,9 +184,11 @@ const CommitPhase: FC<Props> = ({
       const identifiers = Object.keys(watchAllFields);
       const values = Object.values(watchAllFields);
       for (let i = 0; i < identifiers.length; i++) {
-        if (values[i] !== "") {
+        if (values[i] !== "" && values[i] !== undefined) {
+          const idenSplit = identifiers[i].split("~");
+
           const val = {
-            identifier: identifiers[i],
+            identifier: `${idenSplit[0]} -- ${idenSplit[1]}`,
             value: values[i],
           };
           summary.push(val);
@@ -213,8 +215,9 @@ const CommitPhase: FC<Props> = ({
           <tr>
             <th>Requested Vote</th>
             <th>Description</th>
+            <th>Timestamp</th>
             <th>Commit Vote</th>
-            {hasVoted ? <th className="center-header">Your Vote</th> : null}
+            <th className="center-header">Your Vote</th>
             <th className="center-header">Vote Status</th>
           </tr>
         </thead>
@@ -243,6 +246,11 @@ const CommitPhase: FC<Props> = ({
                 <td>
                   <div className="description">{el.description}</div>
                 </td>
+                <td>
+                  <div>
+                    {el.timestamp} ({el.unix}){" "}
+                  </div>
+                </td>
                 <td className="input-cell">
                   {el.identifier.includes("Admin") ? (
                     <div className="select">
@@ -264,14 +272,12 @@ const CommitPhase: FC<Props> = ({
                           },
                         ]}
                       />
-
-                      {/* <Select control={control} name={`${el.identifier}`} /> */}
                     </div>
                   ) : (
                     <TextInput
                       label="Input your vote."
                       control={control}
-                      name={`${el.identifier}`}
+                      name={`${el.identifier}~${el.timestamp}~${el.ancHex}`}
                       placeholder="0.000"
                       variant="text"
                     />
@@ -284,7 +290,11 @@ const CommitPhase: FC<Props> = ({
                       <p className="vote">{el.vote}</p>
                     </div>
                   </td>
-                ) : null}
+                ) : (
+                  <td>
+                    <p className="empty-vote">-</p>
+                  </td>
+                )}
 
                 <td>
                   <div className="status">

--- a/src/features/vote/RevealPhase.tsx
+++ b/src/features/vote/RevealPhase.tsx
@@ -69,6 +69,7 @@ const RevealPhase: FC<Props> = ({
           <tr>
             <th>Requested Vote</th>
             <th>Description</th>
+            <th>Timestamp</th>
             <th className="center-header">Your Vote</th>
             <th className="center-header">Vote Status</th>
           </tr>
@@ -97,6 +98,9 @@ const RevealPhase: FC<Props> = ({
                 </td>
                 <td>
                   <div className="description">{el.description}</div>
+                </td>
+                <td>
+                  <div>{el.timestamp}</div>
                 </td>
                 <td>
                   <div>

--- a/src/features/vote/RevealPhase.tsx
+++ b/src/features/vote/RevealPhase.tsx
@@ -24,6 +24,7 @@ interface Props {
   round: Round;
   revealedVotes: VoteRevealed[];
   refetchEncryptedVotes: Function;
+  refetchVoteRevealedEvents: Function;
   setViewDetailsModalState: Dispatch<SetStateAction<ModalState>>;
   openViewDetailsModal: () => void;
 }
@@ -39,6 +40,7 @@ const RevealPhase: FC<Props> = ({
   refetchEncryptedVotes,
   openViewDetailsModal,
   setViewDetailsModalState,
+  refetchVoteRevealedEvents,
 }) => {
   const { tableValues, postRevealData, setPostRevealData } = useTableValues(
     activeRequests,
@@ -160,6 +162,7 @@ const RevealPhase: FC<Props> = ({
                 if (vc && postRevealData.length) {
                   revealVotes(vc, postRevealData).then((res) => {
                     // refetch votes.
+                    refetchVoteRevealedEvents();
                     refetchEncryptedVotes();
                     setPostRevealData([]);
                   });

--- a/src/features/vote/RevealPhase.tsx
+++ b/src/features/vote/RevealPhase.tsx
@@ -14,6 +14,7 @@ import { snapshotCurrentRound } from "web3/post/snapshotCurrentRound";
 import { VoteRevealed } from "web3/get/queryVotesRevealedEvents";
 import { ModalState } from "./ActiveRequests";
 import useTableValues from "./useTableValues";
+import { ErrorContext } from "common/context/ErrorContext";
 
 interface Props {
   isConnected: boolean;
@@ -51,6 +52,7 @@ const RevealPhase: FC<Props> = ({
   const {
     state: { network, signer, provider },
   } = useContext(OnboardContext);
+  const { addError } = useContext(ErrorContext);
 
   const { votingContract, designatedVotingContract } = useVotingContract(
     signer,
@@ -160,12 +162,16 @@ const RevealPhase: FC<Props> = ({
                 let vc = votingContract;
                 if (designatedVotingContract) vc = designatedVotingContract;
                 if (vc && postRevealData.length) {
-                  revealVotes(vc, postRevealData).then((res) => {
-                    // refetch votes.
-                    refetchVoteRevealedEvents();
-                    refetchEncryptedVotes();
-                    setPostRevealData([]);
-                  });
+                  return revealVotes(vc, postRevealData)
+                    .then((res) => {
+                      // refetch votes.
+                      refetchVoteRevealedEvents();
+                      refetchEncryptedVotes();
+                      setPostRevealData([]);
+                    })
+                    .catch((err) => {
+                      addError(err.message);
+                    });
                 }
               }}
               variant="secondary"

--- a/src/features/vote/RevealPhase.tsx
+++ b/src/features/vote/RevealPhase.tsx
@@ -104,6 +104,11 @@ const RevealPhase: FC<Props> = ({
                 </td>
                 <td>
                   <div>
+                    {el.timestamp} ({el.unix})
+                  </div>
+                </td>
+                <td>
+                  <div>
                     <p className="vote">{el.vote}</p>
                   </div>
                 </td>

--- a/src/features/vote/RevealPhase.tsx
+++ b/src/features/vote/RevealPhase.tsx
@@ -169,9 +169,7 @@ const RevealPhase: FC<Props> = ({
                       refetchEncryptedVotes();
                       setPostRevealData([]);
                     })
-                    .catch((err) => {
-                      addError(err.message);
-                    });
+                    .catch((err) => addError(err));
                 }
               }}
               variant="secondary"

--- a/src/features/vote/SubmitCommitsModal.tsx
+++ b/src/features/vote/SubmitCommitsModal.tsx
@@ -77,7 +77,15 @@ const _SubmitCommitsModal: ForwardRefRenderFunction<
 ) => {
   return (
     <>
-      <Modal isOpen={isOpen} onClose={() => close()} ref={externalRef}>
+      <Modal
+        isOpen={isOpen}
+        onClose={() => {
+          close();
+          setModalState("init");
+          setSubmitErrorMessage("");
+        }}
+        ref={externalRef}
+      >
         <ModalWrapper>
           <div className="icon-wrapper">
             {modalState === "pending" ? (

--- a/src/features/vote/Vote.tsx
+++ b/src/features/vote/Vote.tsx
@@ -8,7 +8,7 @@ import ActiveRequests from "./ActiveRequests";
 import PastRequests from "./PastRequests";
 import UpcomingRequests from "./UpcomingRequests";
 
-import useVoteData from "common/hooks/useVoteData";
+import useVoteData, { PriceRequestRound } from "common/hooks/useVoteData";
 import { OnboardContext } from "common/context/OnboardContext";
 import {
   usePriceRequestAddedEvents,
@@ -35,7 +35,7 @@ const Vote: FC<Props> = ({ signingKeys }) => {
 
   const { state } = useContext(OnboardContext);
 
-  const { data: voteSummaryData } = useVoteData();
+  const { data: voteSummaryData = [] as PriceRequestRound[] } = useVoteData();
 
   const { votingAddress, hotAddress } = useVotingAddress(
     state.address,
@@ -53,7 +53,7 @@ const Vote: FC<Props> = ({ signingKeys }) => {
 
   const { data: priceRequestsAdded } = usePriceRequestAddedEvents();
   const { data: activeRequests } = usePendingRequests();
-  const { data: roundId } = useCurrentRoundId();
+  const { data: roundId = "" } = useCurrentRoundId();
 
   const { data: revealedVotes, refetch: refetchVoteRevealedEvents } =
     useVotesRevealedEvents(votingContract, votingAddress);

--- a/src/features/vote/Vote.tsx
+++ b/src/features/vote/Vote.tsx
@@ -21,7 +21,8 @@ import {
 } from "hooks";
 
 import { PriceRequestAdded } from "web3/get/queryPriceRequestAddedEvents";
-
+import { PendingRequest } from "web3/get/queryGetPendingRequests";
+import { VoteRevealed } from "web3/get/queryVotesRevealedEvents";
 import { SigningKeys } from "App";
 
 interface Props {
@@ -51,12 +52,16 @@ const Vote: FC<Props> = ({ signingKeys }) => {
     hotAddress
   );
 
-  const { data: priceRequestsAdded } = usePriceRequestAddedEvents();
-  const { data: activeRequests } = usePendingRequests();
+  const { data: priceRequestsAdded = [] as PriceRequestAdded[] } =
+    usePriceRequestAddedEvents();
+  const { data: activeRequests = [] as PendingRequest[] } =
+    usePendingRequests();
   const { data: roundId = "" } = useCurrentRoundId();
 
-  const { data: revealedVotes, refetch: refetchVoteRevealedEvents } =
-    useVotesRevealedEvents(votingContract, votingAddress);
+  const {
+    data: revealedVotes = [] as VoteRevealed[],
+    refetch: refetchVoteRevealedEvents,
+  } = useVotesRevealedEvents(votingContract, votingAddress);
 
   const signingPK =
     hotAddress && signingKeys[hotAddress]

--- a/src/features/vote/Vote.tsx
+++ b/src/features/vote/Vote.tsx
@@ -21,7 +21,6 @@ import {
 } from "hooks";
 
 import { PriceRequestAdded } from "web3/get/queryPriceRequestAddedEvents";
-import { ErrorContext } from "common/context/ErrorContext";
 
 import { SigningKeys } from "App";
 
@@ -33,7 +32,6 @@ const Vote: FC<Props> = ({ signingKeys }) => {
   const [upcomingRequests, setUpcomingRequests] = useState<PriceRequestAdded[]>(
     []
   );
-  const { addError } = useContext(ErrorContext);
 
   const { state } = useContext(OnboardContext);
 
@@ -68,13 +66,7 @@ const Vote: FC<Props> = ({ signingKeys }) => {
       : "";
 
   const { data: encryptedVotes, refetch: refetchEncryptedVotes } =
-    useEncryptedVotesEvents(
-      votingContract,
-      votingAddress,
-      signingPK,
-      roundId,
-      addError
-    );
+    useEncryptedVotesEvents(votingContract, votingAddress, signingPK, roundId);
 
   useEffect(() => {
     if (priceRequestsAdded.length) {

--- a/src/features/vote/Vote.tsx
+++ b/src/features/vote/Vote.tsx
@@ -55,10 +55,8 @@ const Vote: FC<Props> = ({ signingKeys }) => {
   const { data: activeRequests } = usePendingRequests();
   const { data: roundId } = useCurrentRoundId();
 
-  const { data: revealedVotes } = useVotesRevealedEvents(
-    votingContract,
-    votingAddress
-  );
+  const { data: revealedVotes, refetch: refetchVoteRevealedEvents } =
+    useVotesRevealedEvents(votingContract, votingAddress);
 
   const signingPK =
     hotAddress && signingKeys[hotAddress]
@@ -97,6 +95,7 @@ const Vote: FC<Props> = ({ signingKeys }) => {
           encryptedVotes={encryptedVotes}
           refetchEncryptedVotes={refetchEncryptedVotes}
           revealedVotes={revealedVotes}
+          refetchVoteRevealedEvents={refetchVoteRevealedEvents}
           votingAddress={votingAddress}
           hotAddress={hotAddress}
         />

--- a/src/features/vote/Vote.tsx
+++ b/src/features/vote/Vote.tsx
@@ -21,6 +21,7 @@ import {
 } from "hooks";
 
 import { PriceRequestAdded } from "web3/get/queryPriceRequestAddedEvents";
+import { ErrorContext } from "common/context/ErrorContext";
 
 import { SigningKeys } from "App";
 
@@ -32,6 +33,7 @@ const Vote: FC<Props> = ({ signingKeys }) => {
   const [upcomingRequests, setUpcomingRequests] = useState<PriceRequestAdded[]>(
     []
   );
+  const { addError } = useContext(ErrorContext);
 
   const { state } = useContext(OnboardContext);
 
@@ -66,7 +68,13 @@ const Vote: FC<Props> = ({ signingKeys }) => {
       : "";
 
   const { data: encryptedVotes, refetch: refetchEncryptedVotes } =
-    useEncryptedVotesEvents(votingContract, votingAddress, signingPK, roundId);
+    useEncryptedVotesEvents(
+      votingContract,
+      votingAddress,
+      signingPK,
+      roundId,
+      addError
+    );
 
   useEffect(() => {
     if (priceRequestsAdded.length) {

--- a/src/features/vote/Vote.tsx
+++ b/src/features/vote/Vote.tsx
@@ -23,6 +23,7 @@ import {
 import { PriceRequestAdded } from "web3/get/queryPriceRequestAddedEvents";
 import { PendingRequest } from "web3/get/queryGetPendingRequests";
 import { VoteRevealed } from "web3/get/queryVotesRevealedEvents";
+import { EncryptedVote } from "web3/get/queryEncryptedVotesEvents";
 import { SigningKeys } from "App";
 
 interface Props {
@@ -70,8 +71,15 @@ const Vote: FC<Props> = ({ signingKeys }) => {
       ? signingKeys[votingAddress].privateKey
       : "";
 
-  const { data: encryptedVotes, refetch: refetchEncryptedVotes } =
-    useEncryptedVotesEvents(votingContract, votingAddress, signingPK, roundId);
+  const {
+    data: encryptedVotes = [] as EncryptedVote[],
+    refetch: refetchEncryptedVotes,
+  } = useEncryptedVotesEvents(
+    votingContract,
+    votingAddress,
+    signingPK,
+    roundId
+  );
 
   useEffect(() => {
     if (priceRequestsAdded.length) {

--- a/src/features/vote/helpers/formatVoteDataToCommit.ts
+++ b/src/features/vote/helpers/formatVoteDataToCommit.ts
@@ -24,9 +24,8 @@ export async function formatVoteDataToCommit(
   await Promise.all(
     activeRequests.map(async (el) => {
       // Compute hash and encrypted vote
-
       if (
-        Object.keys(data).includes(`${el.identifier}~${el.time}~${el.idenHex}`)
+        Object.keys(data).includes(`${el.identifier}~${el.time}~${el.ancHex}`)
       ) {
         const datum = {} as PostCommitVote;
         // datum.identifier = stringToBytes32(el.identifier);
@@ -43,7 +42,7 @@ export async function formatVoteDataToCommit(
         }
 
         datum.ancillaryData = ancData;
-        let price = data[`${el.identifier}~${el.time}~${el.idenHex}`];
+        let price = data[`${el.identifier}~${el.time}~${el.ancHex}`];
         // change yes/no to numbers.
         // When converting price to wei here, we need precision
         // Default to 18 decimals -- could be different.
@@ -82,8 +81,6 @@ export async function formatVoteDataToCommit(
       }
     })
   );
-
-  console.log("post values", postValues);
 
   return postValues;
 }

--- a/src/features/vote/helpers/formatVoteDataToCommit.ts
+++ b/src/features/vote/helpers/formatVoteDataToCommit.ts
@@ -24,7 +24,10 @@ export async function formatVoteDataToCommit(
   await Promise.all(
     activeRequests.map(async (el) => {
       // Compute hash and encrypted vote
-      if (Object.keys(data).includes(el.identifier)) {
+
+      if (
+        Object.keys(data).includes(`${el.identifier}~${el.time}~${el.idenHex}`)
+      ) {
         const datum = {} as PostCommitVote;
         // datum.identifier = stringToBytes32(el.identifier);
         datum.identifier = el.idenHex;
@@ -40,7 +43,7 @@ export async function formatVoteDataToCommit(
         }
 
         datum.ancillaryData = ancData;
-        let price = data[el.identifier];
+        let price = data[`${el.identifier}~${el.time}~${el.idenHex}`];
         // change yes/no to numbers.
         // When converting price to wei here, we need precision
         // Default to 18 decimals -- could be different.
@@ -79,6 +82,8 @@ export async function formatVoteDataToCommit(
       }
     })
   );
+
+  console.log("post values", postValues);
 
   return postValues;
 }

--- a/src/features/vote/styled/CommitPhase.styled.tsx
+++ b/src/features/vote/styled/CommitPhase.styled.tsx
@@ -49,6 +49,9 @@ export const FormWrapper = styled.form<StyledFormProps>`
             props.isConnected && props.publicKey ? "all" : "none"};
           opacity: ${(props) =>
             props.isConnected && props.publicKey ? "1" : "0.5"};
+          label {
+            display: block;
+          }
         }
       }
       thead {
@@ -83,6 +86,9 @@ export const FormWrapper = styled.form<StyledFormProps>`
       }
       .vote {
         margin: 0 auto;
+      }
+      .empty-vote {
+        text-align: center;
       }
     }
     .end-row {

--- a/src/features/vote/styled/CommitPhase.styled.tsx
+++ b/src/features/vote/styled/CommitPhase.styled.tsx
@@ -44,6 +44,12 @@ export const FormWrapper = styled.form<StyledFormProps>`
           props.isConnected && props.publicKey ? "auto" : "not-allowed"};
         input,
         .select {
+          div {
+            margin: 1rem 0;
+          }
+          ul {
+            background-color: #fff;
+          }
           // Double check the user is connected and has signed the message so their public / private signing keys are defined.
           pointer-events: ${(props) =>
             props.isConnected && props.publicKey ? "all" : "none"};
@@ -76,6 +82,7 @@ export const FormWrapper = styled.form<StyledFormProps>`
           .description {
             max-width: 500px;
           }
+          /* padding-bottom: 0.5rem; */
         }
 
         td:last-child {

--- a/src/features/vote/useTableValues.ts
+++ b/src/features/vote/useTableValues.ts
@@ -38,7 +38,7 @@ export default function useTableValues(
           vote: "-",
           identifier: el.identifier,
           revealed: false,
-          ancHex: el.idenHex,
+          ancHex: el.ancHex,
           description: "",
           timestamp: DateTime.fromSeconds(Number(el.time)).toLocaleString({
             month: "short",
@@ -97,6 +97,7 @@ export default function useTableValues(
         const datum = {} as TableValue;
         datum.ancillaryData = el.ancillaryData;
         datum.identifier = el.identifier;
+        datum.ancHex = el.ancHex;
         let vote = "-";
         // I believe latest events are on bottom. requires testing.
         const findVote = latestVotesFirst.find(

--- a/src/features/vote/useTableValues.ts
+++ b/src/features/vote/useTableValues.ts
@@ -15,6 +15,7 @@ interface TableValue {
   revealed: boolean;
   ancHex: string;
   timestamp: string;
+  unix: string;
   description?: string;
 }
 
@@ -45,9 +46,11 @@ export default function useTableValues(
             year: "numeric",
             hour: "2-digit",
             minute: "2-digit",
+            second: "2-digit",
             hourCycle: "h24",
             timeZoneName: "short",
           }),
+          unix: el.time,
         };
       });
 
@@ -61,7 +64,11 @@ export default function useTableValues(
           let description = "Price request.";
 
           if (umipNumber) {
-            description = await (await fetchUmip(umipNumber)).description;
+            try {
+              description = (await fetchUmip(umipNumber)).description;
+            } catch (err) {
+              description = "No data available for this UMIP.";
+            }
           }
 
           return {
@@ -74,7 +81,9 @@ export default function useTableValues(
       descriptionsAdded.then((results) => {
         const values = [] as TableValue[];
         results.forEach((result) => {
-          if (result.status === "fulfilled") values.push(result.value);
+          if (result.status === "fulfilled") {
+            values.push(result.value);
+          }
         });
         setTableValues(values);
       });
@@ -130,6 +139,7 @@ export default function useTableValues(
           hourCycle: "h24",
           timeZoneName: "short",
         });
+        datum.unix = el.time;
 
         tv.push(datum);
         // Gather up PostRevealData here to save complexity
@@ -165,7 +175,11 @@ export default function useTableValues(
           let description = "Price request.";
 
           if (umipNumber) {
-            description = (await fetchUmip(umipNumber)).description;
+            try {
+              description = (await fetchUmip(umipNumber)).description;
+            } catch (err) {
+              description = "No data available for this UMIP.";
+            }
           }
 
           return {
@@ -178,7 +192,9 @@ export default function useTableValues(
       descriptionsAdded.then((results) => {
         const values = [] as TableValue[];
         results.forEach((result) => {
-          if (result.status === "fulfilled") values.push(result.value);
+          if (result.status === "fulfilled") {
+            values.push(result.value);
+          }
         });
 
         setTableValues(values);

--- a/src/features/vote/useTableValues.ts
+++ b/src/features/vote/useTableValues.ts
@@ -180,6 +180,7 @@ export default function useTableValues(
         results.forEach((result) => {
           if (result.status === "fulfilled") values.push(result.value);
         });
+
         setTableValues(values);
       });
 

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -269,17 +269,15 @@ const Wallet: FC<Props> = ({ signingKeys }) => {
                 <span
                   onClick={() => {
                     if (votingContract && votesRevealed && multicallContract) {
-                      const unclaimedRewards = votesRevealed.filter(function (
-                        obj
-                      ) {
-                        return !rewardsEvents.some(function (obj2) {
-                          return (
-                            obj.identifier === obj2.identifier &&
-                            obj.roundId === obj2.roundId &&
-                            obj.ancillaryData === obj2.ancillaryData
-                          );
-                        });
-                      });
+                      const unclaimedRewards = votesRevealed.filter(
+                        (x) =>
+                          !rewardsEvents.some(
+                            (y) =>
+                              x.identifier === y.identifier &&
+                              x.roundId === y.roundId &&
+                              x.ancillaryData === y.ancillaryData
+                          )
+                      );
 
                       collectRewards(
                         votingContract,

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -60,6 +60,7 @@ const Wallet: FC<Props> = ({ signingKeys }) => {
     signer,
     address,
     network,
+    notify,
   } = useOnboard();
 
   const { addError } = useContext(ErrorContext);
@@ -281,16 +282,25 @@ const Wallet: FC<Props> = ({ signingKeys }) => {
                           )
                       );
 
-                      return collectRewards(
-                        votingContract,
-                        unclaimedRewards,
-                        multicallContract
-                      ) // wait for at least 1 block conf.
-                        .then((tx) => tx.wait(1))
-                        .then((conf: any) => {
-                          setAvailableRewards(DEFAULT_BALANCE);
-                        })
-                        .catch((err) => addError(err));
+                      return (
+                        collectRewards(
+                          votingContract,
+                          unclaimedRewards,
+                          multicallContract
+                        )
+                          // wait for at least 1 block conf.
+                          .then((tx) => {
+                            if (tx) {
+                              if (notify) notify.hash(tx.hash);
+
+                              tx.wait(1)
+                                .then((conf: any) => {
+                                  setAvailableRewards(DEFAULT_BALANCE);
+                                })
+                                .catch((err: any) => addError(err));
+                            }
+                          })
+                      );
                     }
                   }}
                   className="Wallet-collect"

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -284,9 +284,13 @@ const Wallet: FC<Props> = ({ signingKeys }) => {
                       return collectRewards(
                         votingContract,
                         unclaimedRewards,
-                        setAvailableRewards,
                         multicallContract
-                      ).catch((err) => addError(err));
+                      ) // wait for at least 1 block conf.
+                        .then((tx) => tx.wait(1))
+                        .then((conf: any) => {
+                          setAvailableRewards(DEFAULT_BALANCE);
+                        })
+                        .catch((err) => addError(err));
                     }
                   }}
                   className="Wallet-collect"

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -27,7 +27,8 @@ import calculateUMATotalValue from "./helpers/calculateUMATotalValue";
 import checkAvailableRewards from "./helpers/checkAvailableRewards";
 import collectRewards from "./helpers/collectRewards";
 import shortenAddress from "./helpers/shortenAddress";
-
+import { RewardsRetrieved } from "web3/get/queryRewardsRetrievedEvents";
+import { VoteRevealed } from "web3/get/queryVotesRevealedEvents";
 import {
   Wrapper,
   Connected,
@@ -87,14 +88,12 @@ const Wallet: FC<Props> = ({ signingKeys }) => {
     hotAddress
   );
 
-  const { data: rewardsEvents } = useRewardsRetrievedEvents(
-    votingContract,
-    votingAddress
-  );
+  const { data: rewardsEvents = [] as RewardsRetrieved[] } =
+    useRewardsRetrievedEvents(votingContract, votingAddress);
 
   const { multicallContract } = useMulticall(signer, isConnected, network);
 
-  const { data: votesRevealed } = useVotesRevealedEvents(
+  const { data: votesRevealed = [] as VoteRevealed[] } = useVotesRevealedEvents(
     votingContract,
     votingAddress
   );

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -185,7 +185,7 @@ const Wallet: FC<Props> = ({ signingKeys }) => {
                 ) : (
                   <Reconnect>
                     {" "}
-                    Sign in rejected. Reconnect to sign in.
+                    Account needs to sign message. Reconnect if sign cancelled.
                   </Reconnect>
                 )}
               </>

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -287,9 +287,7 @@ const Wallet: FC<Props> = ({ signingKeys }) => {
                         unclaimedRewards,
                         setAvailableRewards,
                         multicallContract
-                      ).catch((err) => {
-                        addError(err.message);
-                      });
+                      ).catch((err) => addError(err));
                     }
                   }}
                   className="Wallet-collect"

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -269,9 +269,21 @@ const Wallet: FC<Props> = ({ signingKeys }) => {
                 <span
                   onClick={() => {
                     if (votingContract && votesRevealed && multicallContract) {
+                      const unclaimedRewards = votesRevealed.filter(function (
+                        obj
+                      ) {
+                        return !rewardsEvents.some(function (obj2) {
+                          return (
+                            obj.identifier === obj2.identifier &&
+                            obj.roundId === obj2.roundId &&
+                            obj.ancillaryData === obj2.ancillaryData
+                          );
+                        });
+                      });
+
                       collectRewards(
                         votingContract,
-                        votesRevealed,
+                        unclaimedRewards,
                         setAvailableRewards,
                         multicallContract
                       );

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import { FC, useState, useEffect } from "react";
+import { FC, useState, useEffect, useContext } from "react";
 import tw from "twin.macro"; // eslint-disable-line
 import { ethers } from "ethers";
 import useModal from "common/hooks/useModal";
@@ -19,6 +19,7 @@ import {
 } from "hooks";
 
 import TwoKeyContractModal from "./TwoKeyContractModal";
+import { ErrorContext } from "common/context/ErrorContext";
 
 // Helpers
 import formatWalletBalance from "./helpers/formatWalletBalance";
@@ -59,6 +60,8 @@ const Wallet: FC<Props> = ({ signingKeys }) => {
     address,
     network,
   } = useOnboard();
+
+  const { addError } = useContext(ErrorContext);
 
   const prevTotalCollected = usePrevious(totalUmaCollected);
   const prevAvailableReweards = usePrevious(availableRewards);
@@ -279,12 +282,14 @@ const Wallet: FC<Props> = ({ signingKeys }) => {
                           )
                       );
 
-                      collectRewards(
+                      return collectRewards(
                         votingContract,
                         unclaimedRewards,
                         setAvailableRewards,
                         multicallContract
-                      );
+                      ).catch((err) => {
+                        addError(err.message);
+                      });
                     }
                   }}
                   className="Wallet-collect"

--- a/src/features/wallet/helpers/collectRewards.ts
+++ b/src/features/wallet/helpers/collectRewards.ts
@@ -1,4 +1,3 @@
-import { Dispatch, SetStateAction } from "react";
 import { ethers } from "ethers";
 import { RewardsRetrieved } from "web3/get/queryRewardsRetrievedEvents";
 import {
@@ -8,8 +7,6 @@ import {
 import { retrieveRewards } from "web3/post/retrieveRewards";
 
 import VotingArtifact from "@uma/core/build/contracts/Voting.json";
-
-const DEFAULT_BALANCE = "0";
 
 // This interface is defined because we are going to batch the requests using the multicallContract: (https://github.com/UMAprotocol/protocol/blob/master/packages/core/contracts/common/interfaces/Multicall.sol)
 interface MulticallCollectRewards {
@@ -21,13 +18,8 @@ interface MulticallCollectRewards {
 export default function collectRewards(
   contract: ethers.Contract,
   data: RewardsRetrieved[],
-  // Type returned by useState variable in Wallet.tsx
-  setAvailableRewards: Dispatch<SetStateAction<string>>,
   multicallContract: ethers.Contract
 ) {
-  const multicallCollectRewards = [] as MulticallCollectRewards[];
-  const votingInterface = new ethers.utils.Interface(VotingArtifact.abi);
-
   // find the unique roundIds
   const uniqueRoundIds = data
     .map((item) => item.roundId)
@@ -35,82 +27,88 @@ export default function collectRewards(
 
   // Do a multicall request if the user is collecting from multiple rounds.
   // Otherwise just call the rewards function directly.
-  if (uniqueRoundIds.length > 1) {
-    uniqueRoundIds.forEach((roundId) => {
-      const mcr = {} as MulticallCollectRewards;
-      const postData = {} as PostRetrieveReward;
-      const pendingRequestData = [] as PendingRequestRetrieveReward[];
+  if (uniqueRoundIds.length === 1) {
+    return collectSingleRoundRewards(data, uniqueRoundIds, contract);
+  }
+  return collectMultipleRoundRewards(
+    data,
+    uniqueRoundIds,
+    contract,
+    multicallContract
+  );
+}
 
-      data.forEach((datum) => {
-        if (datum.roundId === roundId) {
-          const pendingRequest = {} as PendingRequestRetrieveReward;
-          postData.roundId = datum.roundId;
-          postData.voterAddress = datum.address;
-          pendingRequest.ancillaryData = datum.ancillaryData
-            ? datum.ancillaryData
-            : "0x";
-          pendingRequest.identifier = ethers.utils.toUtf8Bytes(
-            datum.identifier
-          );
-          pendingRequest.time = datum.time;
-          pendingRequestData.push(pendingRequest);
-        }
-      });
+// Query the contract direct to retrieve rewards if it's only for a single round to save on gas.
+function collectSingleRoundRewards(
+  data: RewardsRetrieved[],
+  // Type returned by useState variable in Wallet.tsx,
+  uniqueRoundIds: string[],
+  contract: ethers.Contract
+) {
+  const postData = {} as PostRetrieveReward;
+  const pendingRequestData = [] as PendingRequestRetrieveReward[];
 
-      postData.pendingRequests = pendingRequestData;
-      mcr.target = contract.address;
-      mcr.callData = votingInterface.encodeFunctionData(
-        "retrieveRewards(address,uint256,(bytes32,uint256,bytes)[])",
-        [postData.voterAddress, postData.roundId, postData.pendingRequests]
-      );
-
-      multicallCollectRewards.push(mcr);
+  uniqueRoundIds.forEach((roundId) => {
+    data.forEach((datum) => {
+      if (datum.roundId === roundId) {
+        const pendingRequest = {} as PendingRequestRetrieveReward;
+        postData.roundId = datum.roundId;
+        postData.voterAddress = datum.address;
+        pendingRequest.ancillaryData = datum.ancillaryData
+          ? datum.ancillaryData
+          : "0x";
+        pendingRequest.identifier = ethers.utils.toUtf8Bytes(datum.identifier);
+        pendingRequest.time = datum.time;
+        pendingRequestData.push(pendingRequest);
+      }
     });
 
-    return (
-      multicallContract.functions["aggregate((address,bytes)[])"](
-        multicallCollectRewards
-      )
-        // wait for at least 1 block conf.
-        .then((tx) => tx.wait(1))
-        .then((conf: any) => {
-          setAvailableRewards(DEFAULT_BALANCE);
-        })
-        .catch((err) => {
-          throw err;
-        })
-    );
-  } else {
+    postData.pendingRequests = pendingRequestData;
+  });
+
+  return retrieveRewards(contract, postData);
+}
+
+function collectMultipleRoundRewards(
+  data: RewardsRetrieved[],
+  // Type returned by useState variable in Wallet.tsx,
+  uniqueRoundIds: string[],
+  contract: ethers.Contract,
+  multicallContract: ethers.Contract
+) {
+  const multicallCollectRewards = [] as MulticallCollectRewards[];
+  const votingInterface = new ethers.utils.Interface(VotingArtifact.abi);
+
+  uniqueRoundIds.forEach((roundId) => {
+    const mcr = {} as MulticallCollectRewards;
     const postData = {} as PostRetrieveReward;
     const pendingRequestData = [] as PendingRequestRetrieveReward[];
 
-    uniqueRoundIds.forEach((roundId) => {
-      data.forEach((datum) => {
-        if (datum.roundId === roundId) {
-          const pendingRequest = {} as PendingRequestRetrieveReward;
-          postData.roundId = datum.roundId;
-          postData.voterAddress = datum.address;
-          pendingRequest.ancillaryData = datum.ancillaryData
-            ? datum.ancillaryData
-            : "0x";
-          pendingRequest.identifier = ethers.utils.toUtf8Bytes(
-            datum.identifier
-          );
-          pendingRequest.time = datum.time;
-          pendingRequestData.push(pendingRequest);
-        }
-      });
-
-      postData.pendingRequests = pendingRequestData;
+    data.forEach((datum) => {
+      if (datum.roundId === roundId) {
+        const pendingRequest = {} as PendingRequestRetrieveReward;
+        postData.roundId = datum.roundId;
+        postData.voterAddress = datum.address;
+        pendingRequest.ancillaryData = datum.ancillaryData
+          ? datum.ancillaryData
+          : "0x";
+        pendingRequest.identifier = ethers.utils.toUtf8Bytes(datum.identifier);
+        pendingRequest.time = datum.time;
+        pendingRequestData.push(pendingRequest);
+      }
     });
 
-    return retrieveRewards(contract, postData)
-      .then((tx) => tx.wait(1))
-      .then((conf: any) => {
-        setAvailableRewards(DEFAULT_BALANCE);
-      })
-      .catch((err) => {
-        throw err;
-      });
-  }
+    postData.pendingRequests = pendingRequestData;
+    mcr.target = contract.address;
+    mcr.callData = votingInterface.encodeFunctionData(
+      "retrieveRewards(address,uint256,(bytes32,uint256,bytes)[])",
+      [postData.voterAddress, postData.roundId, postData.pendingRequests]
+    );
+
+    multicallCollectRewards.push(mcr);
+  });
+
+  return multicallContract.functions["aggregate((address,bytes)[])"](
+    multicallCollectRewards
+  );
 }

--- a/src/features/wallet/helpers/collectRewards.ts
+++ b/src/features/wallet/helpers/collectRewards.ts
@@ -76,7 +76,9 @@ export default function collectRewards(
         .then((conf: any) => {
           setAvailableRewards(DEFAULT_BALANCE);
         })
-        .catch((err) => console.log("err in retrieve rewards", err))
+        .catch((err) => {
+          throw err;
+        })
     );
   } else {
     const postData = {} as PostRetrieveReward;
@@ -107,6 +109,8 @@ export default function collectRewards(
       .then((conf: any) => {
         setAvailableRewards(DEFAULT_BALANCE);
       })
-      .catch((err) => console.log("err in retrieve rewards", err));
+      .catch((err) => {
+        throw err;
+      });
   }
 }

--- a/src/features/wallet/helpers/collectRewards.ts
+++ b/src/features/wallet/helpers/collectRewards.ts
@@ -76,24 +76,21 @@ function collectMultipleRoundRewards(
 
   uniqueRoundIds.forEach((roundId) => {
     const mcr = {} as MulticallCollectRewards;
-    const postData = {} as PostRetrieveReward;
-    const pendingRequestData = [] as PendingRequestRetrieveReward[];
+    const postData = {
+      voterAddress: data[0].address,
+      roundId,
+    } as PostRetrieveReward;
 
-    data.forEach((datum) => {
-      if (datum.roundId === roundId) {
-        const pendingRequest = {} as PendingRequestRetrieveReward;
-        postData.roundId = datum.roundId;
-        postData.voterAddress = datum.address;
-        pendingRequest.ancillaryData = datum.ancillaryData
-          ? datum.ancillaryData
-          : "0x";
-        pendingRequest.identifier = ethers.utils.toUtf8Bytes(datum.identifier);
-        pendingRequest.time = datum.time;
-        pendingRequestData.push(pendingRequest);
-      }
-    });
+    postData.pendingRequests = data
+      .filter((datum) => datum.roundId === roundId)
+      .map(
+        (datum): PendingRequestRetrieveReward => ({
+          ...datum,
+          ancillaryData: datum.ancillaryData ? datum.ancillaryData : "0x",
+          identifier: ethers.utils.toUtf8Bytes(datum.identifier),
+        })
+      );
 
-    postData.pendingRequests = pendingRequestData;
     mcr.target = contract.address;
     mcr.callData = votingInterface.encodeFunctionData(
       "retrieveRewards(address,uint256,(bytes32,uint256,bytes)[])",

--- a/src/features/wallet/helpers/collectRewards.ts
+++ b/src/features/wallet/helpers/collectRewards.ts
@@ -27,12 +27,12 @@ export default function collectRewards(
 ) {
   const multicallCollectRewards = [] as MulticallCollectRewards[];
   const votingInterface = new ethers.utils.Interface(VotingArtifact.abi);
-
+  console.log("data", data);
   // find the unique roundIds
   const uniqueRoundIds = data
     .map((item) => item.roundId)
     .filter((value, index, self) => self.indexOf(value) === index);
-
+  console.log("UNIQUE ROUND IDS", uniqueRoundIds);
   // Do a multicall request if the user is collecting from multiple rounds.
   // Otherwise just call the rewards function directly.
   if (uniqueRoundIds.length > 1) {
@@ -79,6 +79,7 @@ export default function collectRewards(
         .catch((err) => console.log("err in retrieve rewards", err))
     );
   } else {
+    console.log("in this else. no MCR");
     const postData = {} as PostRetrieveReward;
     const pendingRequestData = [] as PendingRequestRetrieveReward[];
 

--- a/src/features/wallet/helpers/collectRewards.ts
+++ b/src/features/wallet/helpers/collectRewards.ts
@@ -27,12 +27,12 @@ export default function collectRewards(
 ) {
   const multicallCollectRewards = [] as MulticallCollectRewards[];
   const votingInterface = new ethers.utils.Interface(VotingArtifact.abi);
-  console.log("data", data);
+
   // find the unique roundIds
   const uniqueRoundIds = data
     .map((item) => item.roundId)
     .filter((value, index, self) => self.indexOf(value) === index);
-  console.log("UNIQUE ROUND IDS", uniqueRoundIds);
+
   // Do a multicall request if the user is collecting from multiple rounds.
   // Otherwise just call the rewards function directly.
   if (uniqueRoundIds.length > 1) {
@@ -79,7 +79,6 @@ export default function collectRewards(
         .catch((err) => console.log("err in retrieve rewards", err))
     );
   } else {
-    console.log("in this else. no MCR");
     const postData = {} as PostRetrieveReward;
     const pendingRequestData = [] as PendingRequestRetrieveReward[];
 

--- a/src/hooks/useCurrentRoundId.ts
+++ b/src/hooks/useCurrentRoundId.ts
@@ -1,7 +1,9 @@
+import { useContext } from "react";
 import provider from "common/utils/web3/createProvider";
 import createVoidSignerVotingContractInstance from "web3/createVoidSignerVotingContractInstance";
 import determineBlockchainNetwork from "web3/helpers/determineBlockchainNetwork";
 import { useQuery } from "react-query";
+import { ErrorContext } from "common/context/ErrorContext";
 
 import { queryCurrentRoundId } from "web3/get/queryCurrentRoundId";
 
@@ -12,16 +14,23 @@ const contract = createVoidSignerVotingContractInstance(
 
 // This can be accessed without logging the user in.
 export default function useCurrentRoundId() {
+  const { addError } = useContext(ErrorContext);
+
   const { data, error, isFetching, refetch } = useQuery<string>(
     "roundId",
     () => {
-      return queryCurrentRoundId(contract).then((res) => {
-        if (res) {
-          return res;
-        } else {
+      return queryCurrentRoundId(contract)
+        .then((res) => {
+          if (res) {
+            return res;
+          } else {
+            return "";
+          }
+        })
+        .catch((err) => {
+          addError(err.message);
           return "";
-        }
-      });
+        });
     }
   );
 

--- a/src/hooks/useCurrentRoundId.ts
+++ b/src/hooks/useCurrentRoundId.ts
@@ -28,7 +28,7 @@ export default function useCurrentRoundId() {
           }
         })
         .catch((err) => {
-          addError(err.message);
+          addError(err);
           return "";
         });
     }

--- a/src/hooks/useCurrentRoundId.ts
+++ b/src/hooks/useCurrentRoundId.ts
@@ -16,27 +16,13 @@ const contract = createVoidSignerVotingContractInstance(
 export default function useCurrentRoundId() {
   const { addError } = useContext(ErrorContext);
 
-  const { data, error, isFetching, refetch } = useQuery<string>(
-    "roundId",
-    () => {
-      return queryCurrentRoundId(contract)
-        .then((res) => {
-          if (res) {
-            return res;
-          } else {
-            return "";
-          }
-        })
-        .catch((err) => {
-          addError(err);
-          return "";
-        });
-    }
-  );
+  const { data, error, isFetching, refetch } = useQuery<
+    string | undefined | void
+  >("roundId", () => {
+    return queryCurrentRoundId(contract)
+      .then((res) => res)
+      .catch((err) => addError(err));
+  });
 
-  if (data) {
-    return { data, error, isFetching, refetch };
-  } else {
-    return { data: "", error, isFetching };
-  }
+  return { data, error, isFetching, refetch };
 }

--- a/src/hooks/useEncryptedVotesEvents.ts
+++ b/src/hooks/useEncryptedVotesEvents.ts
@@ -9,7 +9,8 @@ export default function useEncryptedVotesEvents(
   contract: ethers.Contract | null,
   address: string | null,
   privateKey: string,
-  roundId: string
+  roundId: string,
+  addError: (message: string) => void
 ) {
   const { data, error, isFetching, refetch } = useQuery<EncryptedVote[]>(
     // key encryped votes by connected address
@@ -34,6 +35,10 @@ export default function useEncryptedVotesEvents(
       enabled: contract !== null && privateKey !== "" && address != null,
     }
   );
+
+  if (error) {
+    addError(`${error}`);
+  }
 
   if (data) {
     return { data, error, isFetching, refetch };

--- a/src/hooks/useEncryptedVotesEvents.ts
+++ b/src/hooks/useEncryptedVotesEvents.ts
@@ -22,23 +22,24 @@ export default function useEncryptedVotesEvents(
         address,
         roundId
         // hotAddress
-      ).then((res) => {
-        if (res) {
-          return res;
-        } else {
-          return [];
-        }
-      });
+      )
+        .then((res) => {
+          if (res) {
+            return res;
+          } else {
+            return [];
+          }
+        })
+        .catch((err) => {
+          addError(`${err.message}`);
+          return [] as EncryptedVote[];
+        });
     },
     {
       // do not run query if any of these are null
       enabled: contract !== null && privateKey !== "" && address != null,
     }
   );
-
-  if (error) {
-    addError(`${error}`);
-  }
 
   if (data) {
     return { data, error, isFetching, refetch };

--- a/src/hooks/useEncryptedVotesEvents.ts
+++ b/src/hooks/useEncryptedVotesEvents.ts
@@ -34,7 +34,7 @@ export default function useEncryptedVotesEvents(
           }
         })
         .catch((err) => {
-          addError(`${err.message}`);
+          addError(err);
           return [] as EncryptedVote[];
         });
     },

--- a/src/hooks/useEncryptedVotesEvents.ts
+++ b/src/hooks/useEncryptedVotesEvents.ts
@@ -1,17 +1,20 @@
+import { useContext } from "react";
 import { useQuery } from "react-query";
 import { ethers } from "ethers";
 import {
   queryEncryptedVotes,
   EncryptedVote,
 } from "web3/get/queryEncryptedVotesEvents";
+import { ErrorContext } from "common/context/ErrorContext";
 
 export default function useEncryptedVotesEvents(
   contract: ethers.Contract | null,
   address: string | null,
   privateKey: string,
-  roundId: string,
-  addError: (message: string) => void
+  roundId: string
 ) {
+  const { addError } = useContext(ErrorContext);
+
   const { data, error, isFetching, refetch } = useQuery<EncryptedVote[]>(
     // key encryped votes by connected address
     ["encryptedVotesEvents", address],

--- a/src/hooks/useEncryptedVotesEvents.ts
+++ b/src/hooks/useEncryptedVotesEvents.ts
@@ -15,7 +15,9 @@ export default function useEncryptedVotesEvents(
 ) {
   const { addError } = useContext(ErrorContext);
 
-  const { data, error, isFetching, refetch } = useQuery<EncryptedVote[]>(
+  const { data, error, isFetching, refetch } = useQuery<
+    EncryptedVote[] | undefined | void
+  >(
     // key encryped votes by connected address
     ["encryptedVotesEvents", address],
     () => {
@@ -26,17 +28,8 @@ export default function useEncryptedVotesEvents(
         roundId
         // hotAddress
       )
-        .then((res) => {
-          if (res) {
-            return res;
-          } else {
-            return [];
-          }
-        })
-        .catch((err) => {
-          addError(err);
-          return [] as EncryptedVote[];
-        });
+        .then((res) => res)
+        .catch((err) => addError(err));
     },
     {
       // do not run query if any of these are null
@@ -44,9 +37,5 @@ export default function useEncryptedVotesEvents(
     }
   );
 
-  if (data) {
-    return { data, error, isFetching, refetch };
-  } else {
-    return { data: [] as EncryptedVote[], error, isFetching, refetch };
-  }
+  return { data, error, isFetching, refetch };
 }

--- a/src/hooks/usePendingRequests.ts
+++ b/src/hooks/usePendingRequests.ts
@@ -21,32 +21,18 @@ const contract = createVoidSignerVotingContractInstance(
 export default function usePendingRequests() {
   const { addError } = useContext(ErrorContext);
   const { data, error, isFetching, refetch } = useQuery<
-    PendingRequest[],
-    Error
+    PendingRequest[] | undefined | void
   >(
     "pendingRequests",
     () => {
       return queryGetPendingRequests(contract)
-        .then((res) => {
-          if (res) {
-            return res;
-          } else {
-            return [];
-          }
-        })
-        .catch((err) => {
-          addError(err);
-          return [] as PendingRequest[];
-        });
+        .then((res) => res)
+        .catch((err) => addError(err));
     },
     {
       retry: false,
     }
   );
 
-  if (data) {
-    return { data, error, isFetching, refetch };
-  } else {
-    return { data: [] as PendingRequest[], error, isFetching, refetch };
-  }
+  return { data, error, isFetching, refetch };
 }

--- a/src/hooks/usePendingRequests.ts
+++ b/src/hooks/usePendingRequests.ts
@@ -35,7 +35,7 @@ export default function usePendingRequests() {
           }
         })
         .catch((err) => {
-          addError(error!.message);
+          addError(err);
           return [] as PendingRequest[];
         });
     },

--- a/src/hooks/usePendingRequests.ts
+++ b/src/hooks/usePendingRequests.ts
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from "react";
+import { useContext } from "react";
 import provider from "common/utils/web3/createProvider";
 import createVoidSignerVotingContractInstance from "web3/createVoidSignerVotingContractInstance";
 
@@ -26,22 +26,23 @@ export default function usePendingRequests() {
   >(
     "pendingRequests",
     () => {
-      return queryGetPendingRequests(contract).then((res) => {
-        if (res) {
-          return res;
-        } else {
-          return [];
-        }
-      });
+      return queryGetPendingRequests(contract)
+        .then((res) => {
+          if (res) {
+            return res;
+          } else {
+            return [];
+          }
+        })
+        .catch((err) => {
+          addError(error!.message);
+          return [] as PendingRequest[];
+        });
     },
     {
       retry: false,
     }
   );
-
-  useEffect(() => {
-    if (error) addError(error!.message);
-  }, [error, addError]);
 
   if (data) {
     return { data, error, isFetching, refetch };

--- a/src/hooks/usePriceRequestAddedEvents.ts
+++ b/src/hooks/usePriceRequestAddedEvents.ts
@@ -17,28 +17,17 @@ const contract = createVoidSignerVotingContractInstance(
 
 export default function usePriceRequestAddedEvents() {
   const { addError } = useContext(ErrorContext);
-  const { data, error, isFetching } = useQuery<PriceRequestAdded[]>(
+  const { data, error, isFetching } = useQuery<
+    PriceRequestAdded[] | undefined | void
+  >(
     "priceRequestAdded",
     () => {
       return queryPriceRequestAdded(contract)
-        .then((res) => {
-          if (res) {
-            return res;
-          } else {
-            return [];
-          }
-        })
-        .catch((err) => {
-          addError(err);
-          return [] as PriceRequestAdded[];
-        });
+        .then((res) => res)
+        .catch((err) => addError(err));
     },
     { enabled: contract !== null }
   );
 
-  if (data) {
-    return { data, error, isFetching };
-  } else {
-    return { data: [] as PriceRequestAdded[], error, isFetching };
-  }
+  return { data, error, isFetching };
 }

--- a/src/hooks/usePriceRequestAddedEvents.ts
+++ b/src/hooks/usePriceRequestAddedEvents.ts
@@ -1,3 +1,4 @@
+import { useContext } from "react";
 import { useQuery } from "react-query";
 import {
   queryPriceRequestAdded,
@@ -7,6 +8,7 @@ import {
 import provider from "common/utils/web3/createProvider";
 import createVoidSignerVotingContractInstance from "web3/createVoidSignerVotingContractInstance";
 import determineBlockchainNetwork from "web3/helpers/determineBlockchainNetwork";
+import { ErrorContext } from "common/context/ErrorContext";
 
 const contract = createVoidSignerVotingContractInstance(
   provider,
@@ -14,16 +16,22 @@ const contract = createVoidSignerVotingContractInstance(
 );
 
 export default function usePriceRequestAddedEvents() {
+  const { addError } = useContext(ErrorContext);
   const { data, error, isFetching } = useQuery<PriceRequestAdded[]>(
     "priceRequestAdded",
     () => {
-      return queryPriceRequestAdded(contract).then((res) => {
-        if (res) {
-          return res;
-        } else {
-          return [];
-        }
-      });
+      return queryPriceRequestAdded(contract)
+        .then((res) => {
+          if (res) {
+            return res;
+          } else {
+            return [];
+          }
+        })
+        .catch((err) => {
+          addError(err.message);
+          return [] as PriceRequestAdded[];
+        });
     },
     { enabled: contract !== null }
   );

--- a/src/hooks/usePriceRequestAddedEvents.ts
+++ b/src/hooks/usePriceRequestAddedEvents.ts
@@ -29,7 +29,7 @@ export default function usePriceRequestAddedEvents() {
           }
         })
         .catch((err) => {
-          addError(err.message);
+          addError(err);
           return [] as PriceRequestAdded[];
         });
     },

--- a/src/hooks/usePriceResolvedEvents.ts
+++ b/src/hooks/usePriceResolvedEvents.ts
@@ -13,28 +13,17 @@ export default function usePriceResolvedEvents(
 ) {
   const { addError } = useContext(ErrorContext);
 
-  const { data, error, isFetching } = useQuery<PriceResolved[]>(
+  const { data, error, isFetching } = useQuery<
+    PriceResolved[] | undefined | void
+  >(
     "priceResolvedEvents",
     () => {
       return queryPriceResolved(contract)
-        .then((res) => {
-          if (res) {
-            return res;
-          } else {
-            return [];
-          }
-        })
-        .catch((err) => {
-          addError(err);
-          return [] as PriceResolved[];
-        });
+        .then((res) => res)
+        .catch((err) => addError(err));
     },
     { enabled: contract !== null }
   );
 
-  if (data) {
-    return { data, error, isFetching };
-  } else {
-    return { data: [] as PriceResolved[], error, isFetching };
-  }
+  return { data, error, isFetching };
 }

--- a/src/hooks/usePriceResolvedEvents.ts
+++ b/src/hooks/usePriceResolvedEvents.ts
@@ -25,7 +25,7 @@ export default function usePriceResolvedEvents(
           }
         })
         .catch((err) => {
-          addError(err.message);
+          addError(err);
           return [] as PriceResolved[];
         });
     },

--- a/src/hooks/usePriceResolvedEvents.ts
+++ b/src/hooks/usePriceResolvedEvents.ts
@@ -1,23 +1,33 @@
+import { useContext } from "react";
+
 import { useQuery } from "react-query";
 import { ethers } from "ethers";
 import {
   queryPriceResolved,
   PriceResolved,
 } from "web3/get/queryPriceResolvedEvents";
+import { ErrorContext } from "common/context/ErrorContext";
 
 export default function usePriceResolvedEvents(
   contract: ethers.Contract | null
 ) {
+  const { addError } = useContext(ErrorContext);
+
   const { data, error, isFetching } = useQuery<PriceResolved[]>(
     "priceResolvedEvents",
     () => {
-      return queryPriceResolved(contract).then((res) => {
-        if (res) {
-          return res;
-        } else {
-          return [];
-        }
-      });
+      return queryPriceResolved(contract)
+        .then((res) => {
+          if (res) {
+            return res;
+          } else {
+            return [];
+          }
+        })
+        .catch((err) => {
+          addError(err.message);
+          return [] as PriceResolved[];
+        });
     },
     { enabled: contract !== null }
   );

--- a/src/hooks/usePriceRoundEvents.ts
+++ b/src/hooks/usePriceRoundEvents.ts
@@ -21,27 +21,14 @@ const contract = createVotingContractInstance(
 export default function usePriceRoundEvents() {
   const { addError } = useContext(ErrorContext);
 
-  const { data, error, isFetching } = useQuery<PriceRound[]>(
+  const { data, error, isFetching } = useQuery<PriceRound[] | undefined | void>(
     "priceRoundEvents",
     () => {
       return queryPriceRoundEvents(contract)
-        .then((res) => {
-          if (res) {
-            return res;
-          } else {
-            return [];
-          }
-        })
-        .catch((err) => {
-          addError(err);
-          return [] as PriceRound[];
-        });
+        .then((res) => res)
+        .catch((err) => addError(err));
     }
   );
 
-  if (data) {
-    return { data, error, isFetching };
-  } else {
-    return { data: [] as PriceRound[], error, isFetching };
-  }
+  return { data, error, isFetching };
 }

--- a/src/hooks/usePriceRoundEvents.ts
+++ b/src/hooks/usePriceRoundEvents.ts
@@ -33,7 +33,7 @@ export default function usePriceRoundEvents() {
           }
         })
         .catch((err) => {
-          addError(err.message);
+          addError(err);
           return [] as PriceRound[];
         });
     }

--- a/src/hooks/usePriceRoundEvents.ts
+++ b/src/hooks/usePriceRoundEvents.ts
@@ -1,3 +1,4 @@
+import { useContext } from "react";
 import provider from "common/utils/web3/createProvider";
 import createVotingContractInstance from "web3/createVotingContractInstance";
 import { useQuery } from "react-query";
@@ -8,6 +9,7 @@ import {
   queryPriceRoundEvents,
   PriceRound,
 } from "web3/get/queryPriceRoundEvents";
+import { ErrorContext } from "common/context/ErrorContext";
 
 const signer = provider.getSigner();
 const contract = createVotingContractInstance(
@@ -17,16 +19,23 @@ const contract = createVotingContractInstance(
 
 // This can be accessed without logging the user in.
 export default function usePriceRoundEvents() {
+  const { addError } = useContext(ErrorContext);
+
   const { data, error, isFetching } = useQuery<PriceRound[]>(
     "priceRoundEvents",
     () => {
-      return queryPriceRoundEvents(contract).then((res) => {
-        if (res) {
-          return res;
-        } else {
-          return [];
-        }
-      });
+      return queryPriceRoundEvents(contract)
+        .then((res) => {
+          if (res) {
+            return res;
+          } else {
+            return [];
+          }
+        })
+        .catch((err) => {
+          addError(err.message);
+          return [] as PriceRound[];
+        });
     }
   );
 

--- a/src/hooks/useRewardsRetrievedEvents.ts
+++ b/src/hooks/useRewardsRetrievedEvents.ts
@@ -13,28 +13,17 @@ export default function useRewardsRetrievedEvents(
 ) {
   const { addError } = useContext(ErrorContext);
 
-  const { data, error, isFetching } = useQuery<RewardsRetrieved[]>(
+  const { data, error, isFetching } = useQuery<
+    RewardsRetrieved[] | undefined | void
+  >(
     "rewardsRetrievedEvents",
     () => {
       return queryRewardsRetrievedEvents(contract, address)
-        .then((res) => {
-          if (res) {
-            return res;
-          } else {
-            return [];
-          }
-        })
-        .catch((err) => {
-          addError(err);
-          return [] as RewardsRetrieved[];
-        });
+        .then((res) => res)
+        .catch((err) => addError(err));
     },
     { enabled: contract !== null && address !== null }
   );
 
-  if (data) {
-    return { data, error, isFetching };
-  } else {
-    return { data: [] as RewardsRetrieved[], error, isFetching };
-  }
+  return { data, error, isFetching };
 }

--- a/src/hooks/useRewardsRetrievedEvents.ts
+++ b/src/hooks/useRewardsRetrievedEvents.ts
@@ -2,7 +2,7 @@ import { useContext } from "react";
 import { useQuery } from "react-query";
 import { ethers } from "ethers";
 import {
-  queryRewardsRetrieved,
+  queryRewardsRetrievedEvents,
   RewardsRetrieved,
 } from "web3/get/queryRewardsRetrievedEvents";
 import { ErrorContext } from "common/context/ErrorContext";
@@ -16,7 +16,7 @@ export default function useRewardsRetrievedEvents(
   const { data, error, isFetching } = useQuery<RewardsRetrieved[]>(
     "rewardsRetrievedEvents",
     () => {
-      return queryRewardsRetrieved(contract, address)
+      return queryRewardsRetrievedEvents(contract, address)
         .then((res) => {
           if (res) {
             return res;

--- a/src/hooks/useRewardsRetrievedEvents.ts
+++ b/src/hooks/useRewardsRetrievedEvents.ts
@@ -25,7 +25,7 @@ export default function useRewardsRetrievedEvents(
           }
         })
         .catch((err) => {
-          addError(err.message);
+          addError(err);
           return [] as RewardsRetrieved[];
         });
     },

--- a/src/hooks/useRewardsRetrievedEvents.ts
+++ b/src/hooks/useRewardsRetrievedEvents.ts
@@ -1,24 +1,33 @@
+import { useContext } from "react";
 import { useQuery } from "react-query";
 import { ethers } from "ethers";
 import {
   queryRewardsRetrieved,
   RewardsRetrieved,
 } from "web3/get/queryRewardsRetrievedEvents";
+import { ErrorContext } from "common/context/ErrorContext";
 
 export default function useRewardsRetrievedEvents(
   contract: ethers.Contract | null,
   address: string | null
 ) {
+  const { addError } = useContext(ErrorContext);
+
   const { data, error, isFetching } = useQuery<RewardsRetrieved[]>(
     "rewardsRetrievedEvents",
     () => {
-      return queryRewardsRetrieved(contract, address).then((res) => {
-        if (res) {
-          return res;
-        } else {
-          return [];
-        }
-      });
+      return queryRewardsRetrieved(contract, address)
+        .then((res) => {
+          if (res) {
+            return res;
+          } else {
+            return [];
+          }
+        })
+        .catch((err) => {
+          addError(err.message);
+          return [] as RewardsRetrieved[];
+        });
     },
     { enabled: contract !== null && address !== null }
   );

--- a/src/hooks/useRound.ts
+++ b/src/hooks/useRound.ts
@@ -18,21 +18,14 @@ const contract = createVoidSignerVotingContractInstance(
 export default function useRound(roundId: number) {
   const { addError } = useContext(ErrorContext);
 
-  const { data, error, isFetching, refetch } = useQuery<Round>(
+  const { data, error, isFetching, refetch } = useQuery<
+    Round | undefined | void
+  >(
     "round",
     () => {
       return queryRounds(contract, roundId)
-        .then((res) => {
-          if (res) {
-            return res;
-          } else {
-            return {} as Round;
-          }
-        })
-        .catch((err) => {
-          addError(err);
-          return {} as Round;
-        });
+        .then((res) => res)
+        .catch((err) => addError(err));
     },
     {
       // Check if we've queried the right roundId
@@ -40,9 +33,5 @@ export default function useRound(roundId: number) {
     }
   );
 
-  if (data) {
-    return { data, error, isFetching, refetch };
-  } else {
-    return { data: {} as Round, error, isFetching };
-  }
+  return { data, error, isFetching, refetch };
 }

--- a/src/hooks/useRound.ts
+++ b/src/hooks/useRound.ts
@@ -30,7 +30,7 @@ export default function useRound(roundId: number) {
           }
         })
         .catch((err) => {
-          addError(err.message);
+          addError(err);
           return {} as Round;
         });
     },

--- a/src/hooks/useRound.ts
+++ b/src/hooks/useRound.ts
@@ -1,3 +1,4 @@
+import { useContext } from "react";
 import provider from "common/utils/web3/createProvider";
 import createVoidSignerVotingContractInstance from "web3/createVoidSignerVotingContractInstance";
 
@@ -6,6 +7,7 @@ import determineBlockchainNetwork from "web3/helpers/determineBlockchainNetwork"
 import { useQuery } from "react-query";
 
 import { queryRounds, Round } from "web3/get/queryRounds";
+import { ErrorContext } from "common/context/ErrorContext";
 
 const contract = createVoidSignerVotingContractInstance(
   provider,
@@ -14,16 +16,23 @@ const contract = createVoidSignerVotingContractInstance(
 
 // This can be accessed without logging the user in.
 export default function useRound(roundId: number) {
+  const { addError } = useContext(ErrorContext);
+
   const { data, error, isFetching, refetch } = useQuery<Round>(
     "round",
     () => {
-      return queryRounds(contract, roundId).then((res) => {
-        if (res) {
-          return res;
-        } else {
+      return queryRounds(contract, roundId)
+        .then((res) => {
+          if (res) {
+            return res;
+          } else {
+            return {} as Round;
+          }
+        })
+        .catch((err) => {
+          addError(err.message);
           return {} as Round;
-        }
-      });
+        });
     },
     {
       // Check if we've queried the right roundId

--- a/src/hooks/useVotePhase.ts
+++ b/src/hooks/useVotePhase.ts
@@ -17,27 +17,13 @@ const contract = createVoidSignerVotingContractInstance(
 export default function useVotePhase() {
   const { addError } = useContext(ErrorContext);
 
-  const { data, error, isFetching, refetch } = useQuery<string>(
-    "votePhase",
-    () => {
-      return queryGetVotePhase(contract)
-        .then((res) => {
-          if (res) {
-            return res;
-          } else {
-            return "";
-          }
-        })
-        .catch((err) => {
-          addError(err);
-          return "";
-        });
-    }
-  );
+  const { data, error, isFetching, refetch } = useQuery<
+    string | undefined | void
+  >("votePhase", () => {
+    return queryGetVotePhase(contract)
+      .then((res) => res)
+      .catch((err) => addError(err));
+  });
 
-  if (data) {
-    return { data, error, isFetching, refetch };
-  } else {
-    return { data: "", error, isFetching };
-  }
+  return { data, error, isFetching, refetch };
 }

--- a/src/hooks/useVotePhase.ts
+++ b/src/hooks/useVotePhase.ts
@@ -29,7 +29,7 @@ export default function useVotePhase() {
           }
         })
         .catch((err) => {
-          addError(err.message);
+          addError(err);
           return "";
         });
     }

--- a/src/hooks/useVotePhase.ts
+++ b/src/hooks/useVotePhase.ts
@@ -1,9 +1,12 @@
+import { useContext } from "react";
 import provider from "common/utils/web3/createProvider";
 import createVoidSignerVotingContractInstance from "web3/createVoidSignerVotingContractInstance";
 import determineBlockchainNetwork from "web3/helpers/determineBlockchainNetwork";
 import { useQuery } from "react-query";
 
 import { queryGetVotePhase } from "web3/get/queryGetVotePhase";
+
+import { ErrorContext } from "common/context/ErrorContext";
 
 const contract = createVoidSignerVotingContractInstance(
   provider,
@@ -12,16 +15,23 @@ const contract = createVoidSignerVotingContractInstance(
 
 // This can be accessed without logging the user in.
 export default function useVotePhase() {
+  const { addError } = useContext(ErrorContext);
+
   const { data, error, isFetching, refetch } = useQuery<string>(
     "votePhase",
     () => {
-      return queryGetVotePhase(contract).then((res) => {
-        if (res) {
-          return res;
-        } else {
+      return queryGetVotePhase(contract)
+        .then((res) => {
+          if (res) {
+            return res;
+          } else {
+            return "";
+          }
+        })
+        .catch((err) => {
+          addError(err.message);
           return "";
-        }
-      });
+        });
     }
   );
 

--- a/src/hooks/useVoteTiming.ts
+++ b/src/hooks/useVoteTiming.ts
@@ -30,7 +30,7 @@ export default function useVoteTiming() {
           }
         })
         .catch((err) => {
-          addError(err.message);
+          addError(err);
           return "";
         });
     }

--- a/src/hooks/useVoteTiming.ts
+++ b/src/hooks/useVoteTiming.ts
@@ -1,3 +1,4 @@
+import { useContext } from "react";
 import provider from "common/utils/web3/createProvider";
 import createVoidSignerVotingContractInstance from "web3/createVoidSignerVotingContractInstance";
 
@@ -6,6 +7,7 @@ import determineBlockchainNetwork from "web3/helpers/determineBlockchainNetwork"
 import { useQuery } from "react-query";
 
 import { queryVoteTiming } from "web3/get/queryVoteTiming";
+import { ErrorContext } from "common/context/ErrorContext";
 
 const contract = createVoidSignerVotingContractInstance(
   provider,
@@ -14,16 +16,23 @@ const contract = createVoidSignerVotingContractInstance(
 
 // This can be accessed without logging the user in.
 export default function useVoteTiming() {
+  const { addError } = useContext(ErrorContext);
+
   const { data, error, isFetching, refetch } = useQuery<string>(
     "voteTiming",
     () => {
-      return queryVoteTiming(contract).then((res) => {
-        if (res) {
-          return res;
-        } else {
+      return queryVoteTiming(contract)
+        .then((res) => {
+          if (res) {
+            return res;
+          } else {
+            return "";
+          }
+        })
+        .catch((err) => {
+          addError(err.message);
           return "";
-        }
-      });
+        });
     }
   );
 

--- a/src/hooks/useVoteTiming.ts
+++ b/src/hooks/useVoteTiming.ts
@@ -18,27 +18,12 @@ const contract = createVoidSignerVotingContractInstance(
 export default function useVoteTiming() {
   const { addError } = useContext(ErrorContext);
 
-  const { data, error, isFetching, refetch } = useQuery<string>(
-    "voteTiming",
-    () => {
-      return queryVoteTiming(contract)
-        .then((res) => {
-          if (res) {
-            return res;
-          } else {
-            return "";
-          }
-        })
-        .catch((err) => {
-          addError(err);
-          return "";
-        });
-    }
-  );
-
-  if (data) {
-    return { data, error, isFetching, refetch };
-  } else {
-    return { data: "", error, isFetching };
-  }
+  const { data, error, isFetching, refetch } = useQuery<
+    string | undefined | void
+  >("voteTiming", () => {
+    return queryVoteTiming(contract)
+      .then((res) => res)
+      .catch((err) => addError(err));
+  });
+  return { data, error, isFetching, refetch };
 }

--- a/src/hooks/useVotesCommittedEvents.ts
+++ b/src/hooks/useVotesCommittedEvents.ts
@@ -23,7 +23,7 @@ export default function useVotesCommittedEvents(
           }
         })
         .catch((err) => {
-          addError(err.message);
+          addError(err);
           return [] as VoteEvent[];
         });
     },

--- a/src/hooks/useVotesCommittedEvents.ts
+++ b/src/hooks/useVotesCommittedEvents.ts
@@ -11,28 +11,15 @@ export default function useVotesCommittedEvents(
 ) {
   const { addError } = useContext(ErrorContext);
 
-  const { data, error, isFetching } = useQuery<VoteEvent[]>(
+  const { data, error, isFetching } = useQuery<VoteEvent[] | undefined | void>(
     "votesCommittedEvents",
     () => {
       return queryVotesCommittedEvents(contract, address)
-        .then((res) => {
-          if (res) {
-            return res;
-          } else {
-            return [];
-          }
-        })
-        .catch((err) => {
-          addError(err);
-          return [] as VoteEvent[];
-        });
+        .then((res) => res)
+        .catch((err) => addError(err));
     },
     { enabled: contract !== null }
   );
 
-  if (data) {
-    return { data, error, isFetching };
-  } else {
-    return { data: [] as VoteEvent[], error, isFetching };
-  }
+  return { data, error, isFetching };
 }

--- a/src/hooks/useVotesCommittedEvents.ts
+++ b/src/hooks/useVotesCommittedEvents.ts
@@ -1,22 +1,31 @@
+import { useContext } from "react";
 import { useQuery } from "react-query";
 import { ethers } from "ethers";
 import { queryVotesCommittedEvents } from "web3/get/queryVotesCommittedEvents";
 import { VoteEvent } from "web3/types.web3";
+import { ErrorContext } from "common/context/ErrorContext";
 
 export default function useVotesCommittedEvents(
   contract: ethers.Contract | null,
   address: string | null
 ) {
+  const { addError } = useContext(ErrorContext);
+
   const { data, error, isFetching } = useQuery<VoteEvent[]>(
     "votesCommittedEvents",
     () => {
-      return queryVotesCommittedEvents(contract, address).then((res) => {
-        if (res) {
-          return res;
-        } else {
-          return [];
-        }
-      });
+      return queryVotesCommittedEvents(contract, address)
+        .then((res) => {
+          if (res) {
+            return res;
+          } else {
+            return [];
+          }
+        })
+        .catch((err) => {
+          addError(err.message);
+          return [] as VoteEvent[];
+        });
     },
     { enabled: contract !== null }
   );

--- a/src/hooks/useVotesRevealedEvents.ts
+++ b/src/hooks/useVotesRevealedEvents.ts
@@ -1,24 +1,33 @@
+import { useContext } from "react";
 import { useQuery } from "react-query";
 import { ethers } from "ethers";
 import {
   queryVotesRevealedEvents,
   VoteRevealed,
 } from "web3/get/queryVotesRevealedEvents";
+import { ErrorContext } from "common/context/ErrorContext";
 
 export default function useVotesRevealedEvents(
   contract: ethers.Contract | null,
   address: string | null
 ) {
+  const { addError } = useContext(ErrorContext);
+
   const { data, error, isFetching, refetch } = useQuery<VoteRevealed[]>(
     "votesRevealedEvents",
     () => {
-      return queryVotesRevealedEvents(contract, address).then((res) => {
-        if (res) {
-          return res;
-        } else {
-          return [];
-        }
-      });
+      return queryVotesRevealedEvents(contract, address)
+        .then((res) => {
+          if (res) {
+            return res;
+          } else {
+            return [];
+          }
+        })
+        .catch((err) => {
+          addError(err.message);
+          return [] as VoteRevealed[];
+        });
     },
     { enabled: contract !== null }
   );

--- a/src/hooks/useVotesRevealedEvents.ts
+++ b/src/hooks/useVotesRevealedEvents.ts
@@ -9,7 +9,7 @@ export default function useVotesRevealedEvents(
   contract: ethers.Contract | null,
   address: string | null
 ) {
-  const { data, error, isFetching } = useQuery<VoteRevealed[]>(
+  const { data, error, isFetching, refetch } = useQuery<VoteRevealed[]>(
     "votesRevealedEvents",
     () => {
       return queryVotesRevealedEvents(contract, address).then((res) => {
@@ -24,8 +24,8 @@ export default function useVotesRevealedEvents(
   );
 
   if (data) {
-    return { data, error, isFetching };
+    return { data, error, isFetching, refetch };
   } else {
-    return { data: [] as VoteRevealed[], error, isFetching };
+    return { data: [] as VoteRevealed[], error, isFetching, refetch };
   }
 }

--- a/src/hooks/useVotesRevealedEvents.ts
+++ b/src/hooks/useVotesRevealedEvents.ts
@@ -25,7 +25,7 @@ export default function useVotesRevealedEvents(
           }
         })
         .catch((err) => {
-          addError(err.message);
+          addError(err);
           return [] as VoteRevealed[];
         });
     },

--- a/src/hooks/useVotesRevealedEvents.ts
+++ b/src/hooks/useVotesRevealedEvents.ts
@@ -13,28 +13,17 @@ export default function useVotesRevealedEvents(
 ) {
   const { addError } = useContext(ErrorContext);
 
-  const { data, error, isFetching, refetch } = useQuery<VoteRevealed[]>(
+  const { data, error, isFetching, refetch } = useQuery<
+    VoteRevealed[] | undefined | void
+  >(
     "votesRevealedEvents",
     () => {
       return queryVotesRevealedEvents(contract, address)
-        .then((res) => {
-          if (res) {
-            return res;
-          } else {
-            return [];
-          }
-        })
-        .catch((err) => {
-          addError(err);
-          return [] as VoteRevealed[];
-        });
+        .then((res) => res)
+        .catch((err) => addError(err));
     },
     { enabled: contract !== null }
   );
 
-  if (data) {
-    return { data, error, isFetching, refetch };
-  } else {
-    return { data: [] as VoteRevealed[], error, isFetching, refetch };
-  }
+  return { data, error, isFetching, refetch };
 }

--- a/src/web3/createOldVotingContractInstance.ts
+++ b/src/web3/createOldVotingContractInstance.ts
@@ -1,0 +1,17 @@
+import OldVotingArtifact from "@uma/core-1-2-2/build/contracts/Voting.json";
+import { ethers } from "ethers";
+
+// We need this because the ABI for the Voting Contract has changed.
+// And we need to collect reward events from previous contracts for display.
+export default function createOldVotingContractInstance(
+  signer: ethers.Signer,
+  contractAddress: string
+) {
+  const contract = new ethers.Contract(
+    contractAddress,
+    OldVotingArtifact.abi,
+    signer
+  );
+
+  return contract;
+}

--- a/src/web3/createVotingContractInstance.ts
+++ b/src/web3/createVotingContractInstance.ts
@@ -1,7 +1,5 @@
 import VotingArtifact from "@uma/core/build/contracts/Voting.json";
 import { ethers } from "ethers";
-import OldVotingArtifact from "@uma/core-1-2-2/build/contracts/Voting.json";
-console.log("does this work??", OldVotingArtifact);
 
 interface Network {
   [key: string]: {

--- a/src/web3/createVotingContractInstance.ts
+++ b/src/web3/createVotingContractInstance.ts
@@ -1,5 +1,7 @@
 import VotingArtifact from "@uma/core/build/contracts/Voting.json";
 import { ethers } from "ethers";
+import OldVotingArtifact from "@uma/core-1-2-2/build/contracts/Voting.json";
+console.log("does this work??", OldVotingArtifact);
 
 interface Network {
   [key: string]: {

--- a/src/web3/get/queryEncryptedVotesEvents.ts
+++ b/src/web3/get/queryEncryptedVotesEvents.ts
@@ -95,6 +95,6 @@ export const queryEncryptedVotes = async (
     );
     return decryptedEvents;
   } catch (err) {
-    console.log("err", err);
+    throw err;
   }
 };

--- a/src/web3/get/queryGetPendingRequests.ts
+++ b/src/web3/get/queryGetPendingRequests.ts
@@ -13,11 +13,9 @@ export interface PendingRequest {
 }
 
 export const queryGetPendingRequests = async (contract: ethers.Contract) => {
-  // console.log("contract", contract);
   try {
-    const requests: Array<
-      Array<[string, ethers.BigNumber, string]>
-    > = await contract.functions.getPendingRequests();
+    const requests: Array<Array<[string, ethers.BigNumber, string]>> =
+      await contract.functions.getPendingRequests();
     if (requests.length) {
       const values = [] as PendingRequest[];
       requests.forEach((el) => {
@@ -48,7 +46,6 @@ export const queryGetPendingRequests = async (contract: ethers.Contract) => {
       return [] as PendingRequest[];
     }
   } catch (err) {
-    console.log("err", err);
-    throw new Error(err.message);
+    throw err;
   }
 };

--- a/src/web3/get/queryRewardsRetrievedEvents.ts
+++ b/src/web3/get/queryRewardsRetrievedEvents.ts
@@ -107,6 +107,6 @@ export const queryRewardsRetrievedEvents = async (
     }
     return rewards;
   } catch (err) {
-    console.log("err", err);
+    throw err;
   }
 };

--- a/src/web3/get/queryRewardsRetrievedEvents.ts
+++ b/src/web3/get/queryRewardsRetrievedEvents.ts
@@ -60,6 +60,9 @@ export const queryRewardsRetrieved = async (
       return datum;
     });
 
+    // On mainnet, look back at old voting contracts to retrieve rewards
+    // for voters who have voted on previous iteration of the contract.
+    // this is largely just for summation of Total UMA Collected.
     if (
       process.env.REACT_APP_CURRENT_ENV === "main" ||
       process.env.REACT_APP_CURRENT_ENV === undefined

--- a/src/web3/get/queryRewardsRetrievedEvents.ts
+++ b/src/web3/get/queryRewardsRetrievedEvents.ts
@@ -2,6 +2,9 @@ import { ethers } from "ethers";
 import { VoteEvent } from "../types.web3";
 import assert from "assert";
 import { VOTER_CONTRACT_BLOCK } from "common/config";
+import { OLD_VOTING_CONTRACT_ADDRESSES } from "common/config";
+import provider from "common/utils/web3/createProvider";
+import createOldVotingContractInstance from "web3/createOldVotingContractInstance";
 
 /*
   event RewardsRetrieved(
@@ -42,7 +45,7 @@ export const queryRewardsRetrieved = async (
 
   try {
     const events = await contract.queryFilter(filter, VOTER_CONTRACT_BLOCK);
-    return events.map((el) => {
+    let rewards = events.map((el) => {
       const { args } = el;
       const datum = {} as RewardsRetrieved;
       if (args) {
@@ -56,6 +59,50 @@ export const queryRewardsRetrieved = async (
 
       return datum;
     });
+
+    if (
+      process.env.REACT_APP_CURRENT_ENV === "main" ||
+      process.env.REACT_APP_CURRENT_ENV === undefined
+    ) {
+      const promises = OLD_VOTING_CONTRACT_ADDRESSES.map(async (addr) => {
+        const oldContract = createOldVotingContractInstance(
+          new ethers.VoidSigner(addr, provider),
+          addr
+        );
+        const oldFilter = oldContract.filters.RewardsRetrieved(
+          address,
+          null,
+          null,
+          null,
+          null
+        );
+
+        const oldEvents = await oldContract.queryFilter(oldFilter, 0);
+        const oldRewards = oldEvents.map((el) => {
+          const { args } = el;
+          const datum = {} as RewardsRetrieved;
+          if (args) {
+            datum.address = args[0];
+            datum.roundId = args[1].toString();
+            datum.identifier = ethers.utils.toUtf8String(args[2]);
+            datum.time = args[3].toString();
+            datum.numTokens = args[4].toString();
+            // Anc didn't exist -- normalize to new data and set default.
+            datum.ancillaryData = "0x";
+          }
+
+          return datum;
+        });
+
+        return oldRewards;
+      });
+
+      return Promise.all(promises).then((results) => {
+        const flatten = results.flat();
+        return [...rewards, ...flatten];
+      });
+    }
+    return rewards;
   } catch (err) {
     console.log("err", err);
   }

--- a/src/web3/get/queryRewardsRetrievedEvents.ts
+++ b/src/web3/get/queryRewardsRetrievedEvents.ts
@@ -22,7 +22,7 @@ export interface RewardsRetrieved extends VoteEvent {
   ancillaryData: string;
 }
 
-export const queryRewardsRetrieved = async (
+export const queryRewardsRetrievedEvents = async (
   contract: ethers.Contract | null,
   address: string | null
 ) => {

--- a/src/web3/post/revealVotes.ts
+++ b/src/web3/post/revealVotes.ts
@@ -23,7 +23,7 @@ export const revealVotes = async (
     const tx = await contract.functions[
       "batchReveal((bytes32,uint256,int256,bytes,int256)[])"
     ](data);
-    console.log("successfully Revealed", tx);
+
     return tx;
   } catch (err) {
     console.log("err in Reveal votes", err);

--- a/src/web3/post/revealVotes.ts
+++ b/src/web3/post/revealVotes.ts
@@ -26,6 +26,6 @@ export const revealVotes = async (
 
     return tx;
   } catch (err) {
-    console.log("err in Reveal votes", err);
+    throw err;
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7821,6 +7821,17 @@ bn.js@^5.0.0, bn.js@^5.1.1, bn.js@^5.1.2, bn.js@^5.1.3:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
   integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
 
+bnc-notify@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/bnc-notify/-/bnc-notify-1.6.1.tgz#5188f45bef6ada3c7de4f0615827fbe36a0a42e9"
+  integrity sha512-gaX+MT0ylJo4hUEG/Y6pcZHO0dVTd2NgNS/SJMADEltwrA8Ghipl5MpmpHK3lfBxc0FTQMswM0oz3TFvB8rDCw==
+  dependencies:
+    bignumber.js "^9.0.0"
+    bnc-sdk "^3.3.4"
+    lodash.debounce "^4.0.8"
+    regenerator-runtime "^0.13.3"
+    uuid "^3.3.3"
+
 bnc-onboard@^1.20.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/bnc-onboard/-/bnc-onboard-1.20.0.tgz#436aa89a2839d6d0702a7689a9ca60f4a957d3cf"
@@ -7850,6 +7861,15 @@ bnc-sdk@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/bnc-sdk/-/bnc-sdk-3.1.1.tgz#60f4a56ee4d7a7a0a6ccb7ae132b7f3a63297eb3"
   integrity sha512-bfQmWf8GlLBnZH0JwioImdU1PqDCjkpddwALBavOYDuKx/NMtJFwUzZP8525xxRrdGX0Lmn0BkJDAvdzJPVklg==
+  dependencies:
+    crypto-es "^1.2.2"
+    rxjs "^6.6.3"
+    sturdy-websocket "^0.1.12"
+
+bnc-sdk@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/bnc-sdk/-/bnc-sdk-3.3.4.tgz#43e7c0e69be92e0706fce5f42ad6a700296078d9"
+  integrity sha512-yBQ1FHBOhPlWGNWHdma5Rx8iHiM0DBxXahyVqmlHdqpX6Idkxzqc1kT6GmV0FnLx/bL8OOcpstPcovn3meu0fQ==
   dependencies:
     crypto-es "^1.2.2"
     rxjs "^6.6.3"
@@ -21073,7 +21093,7 @@ regenerator-runtime@^0.11.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
-regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
+regenerator-runtime@^0.13.3, regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
   version "0.13.7"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
   integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
@@ -24423,7 +24443,7 @@ uuid@8.3.2, uuid@^8.0.0, uuid@^8.3.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
-uuid@^3.1.0, uuid@^3.3.2, uuid@^3.4.0:
+uuid@^3.1.0, uuid@^3.3.2, uuid@^3.3.3, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==


### PR DESCRIPTION
**Motivation**
1) Errors now propagate up to a notification for the user from event calls.
2) Total rewards can be read from past contracts on mainnet.
3) To save on gas, we avoid multicall.
4) Refresh app on network change to avoid any general app errors.

**Summary**

https://app.clubhouse.io/uma-project/story/835/rewards-are-not-accurate-ability-to-query-rewards-earned-from-past-contracts

https://app.clubhouse.io/uma-project/story/842/if-the-decryption-fails-the-dapp-does-not-propagate-that-error-to-the-user

https://app.clubhouse.io/uma-project/story/860/troubleshoot-why-new-voter-dapp-is-more-expensive-than-the-old-voter-dapp

https://app.clubhouse.io/uma-project/story/893/refresh-voter-dapp-on-network-change

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested