### PR TITLE
feat/bugs: Various bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "node-sass": "^5.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-hook-form": "^6.15.5",
+    "react-hook-form": "7",
     "react-markdown": "^6.0.2",
     "react-query": "^3.13.3",
     "react-router-dom": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "node-sass": "^5.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-hook-form": "7",
+    "react-hook-form": "^7",
     "react-markdown": "^6.0.2",
     "react-query": "^3.13.3",
     "react-router-dom": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
     "react-toastify": "^7.0.3",
+    "react-tooltip": "^4.2.19",
     "tailwindcss": "^2.0.4",
     "truffle": "^5.3.0",
     "twin.macro": "^2.3.1",

--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="UMA Voter dApp" />
+    <meta property="og:title" content="UMA Voter dApp" />
+    <meta
+      property="og:description"
+      content="UMA's Voting application for governance and price requests."
+    />
+    <meta property="og:image" content="%PUBLIC_URL%/favicon.ico" />
+    <meta name="twitter:site" content="UMA Voter dApp" />
+    <meta
+      name="twitter:card"
+      content="UMA's Voting application for governance and price requests."
+    />
+    <meta name="twitter:creator" content="@UMAprotocol" />
+    <meta name="twitter:image" content="%PUBLIC_URL%/favicon.ico" />
     <!-- <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo.png" /> -->
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/src/common/apollo/queries.ts
+++ b/src/common/apollo/queries.ts
@@ -1,8 +1,8 @@
 import { gql } from "@apollo/client";
 
 export const PRICE_REQUEST_VOTING_DATA = gql`
-  query priceRequestRounds {
-    priceRequestRounds {
+  query priceRequestRounds($orderBy: String, $orderDirection: String) {
+    priceRequestRounds(first: 1000) {
       id
       identifier {
         id

--- a/src/common/components/dropdown/Dropdown.styled.tsx
+++ b/src/common/components/dropdown/Dropdown.styled.tsx
@@ -38,6 +38,7 @@ export const DropdownList = styled.ul<IDropdownStyledProps>`
   width: 250px;
   border-radius: 8px;
   color: #ff4b4b;
+  z-index: 1000;
 `;
 export const DropdownListItem = styled.li<IDropdownStyledProps>`
   padding: 5px;

--- a/src/common/components/modal/Modal.tsx
+++ b/src/common/components/modal/Modal.tsx
@@ -9,25 +9,23 @@ type Props = {
   onClose: () => void;
 };
 
-const _Modal: ForwardRefRenderFunction<
-  HTMLElement,
-  PropsWithChildren<Props>
-> = ({ children, isOpen, onClose }, externalRef) => {
-  if (!isOpen) {
-    return null;
-  }
-  return (
-    <Portal>
-      <Wrapper ref={externalRef} coords={{ y: window.scrollY }}>
-        <ExitButton onClick={onClose}>
-          <Times />
-        </ExitButton>
-        <Content>{children}</Content>
-      </Wrapper>
-      <BgBlur coords={{ y: window.scrollY }} />
-    </Portal>
-  );
-};
+const _Modal: ForwardRefRenderFunction<HTMLElement, PropsWithChildren<Props>> =
+  ({ children, isOpen, onClose }, externalRef) => {
+    if (!isOpen) {
+      return null;
+    }
+    return (
+      <Portal>
+        <Wrapper ref={externalRef} coords={{ y: window.scrollY }}>
+          <ExitButton onClick={onClose}>
+            <Times />
+          </ExitButton>
+          <Content>{children}</Content>
+        </Wrapper>
+        <BgBlur coords={{ y: window.scrollY }} />
+      </Portal>
+    );
+  };
 
 const Modal = forwardRef(_Modal);
 Modal.displayName = "Modal";
@@ -49,7 +47,7 @@ export const Wrapper = styled.aside<StyledProps>`
       : `${DEFAULT_TOP_VALUE}px`;
   }};
   overflow-y: scroll;
-  max-height: 800px;
+  max-height: 80vh;
 `;
 
 const Content = tw.div`pb-7 px-5`;

--- a/src/common/components/navbar/Navbar.tsx
+++ b/src/common/components/navbar/Navbar.tsx
@@ -15,7 +15,7 @@ const Navbar: FC = () => {
       <div tw="inline-flex items-center">
         <Link to="/" tw=""></Link>
         <div tw="flex place-items-end">
-          <Link className="link" to="/" tw="px-5 py-3">
+          <Link className="link active" to="/" tw="px-5 py-3">
             Vote
           </Link>
           <Link className="link" to="/" tw="px-5 py-3">
@@ -93,9 +93,16 @@ const StyledNavbar = styled.nav`
     }
   }
   .link {
+    &.active {
+      color: #ff4a4a;
+      &:hover {
+        text-decoration: underline;
+      }
+    }
     &:hover {
       transition: color 0.3s;
       color: #ff4a4a;
+      text-decoration: underline;
     }
   }
 `;

--- a/src/common/components/text-input/TextInput.tsx
+++ b/src/common/components/text-input/TextInput.tsx
@@ -1,5 +1,9 @@
 /** @jsxImportSource @emotion/react */
-import { ForwardRefRenderFunction, forwardRef } from "react";
+import {
+  ForwardRefRenderFunction,
+  forwardRef,
+  ChangeEventHandler,
+} from "react";
 
 import tw, { styled } from "twin.macro"; // eslint-disable-line
 import { useController, Control } from "react-hook-form";
@@ -10,6 +14,7 @@ interface Props {
   variant?: "text" | "search" | "currency";
   label?: string;
   placeholder?: string;
+  onChange?: ChangeEventHandler<HTMLInputElement>;
 }
 
 const _TextInput: ForwardRefRenderFunction<HTMLInputElement, Props> = (
@@ -27,7 +32,7 @@ const _TextInput: ForwardRefRenderFunction<HTMLInputElement, Props> = (
           placeholder={props.placeholder}
           ref={field.ref}
           value={field.value}
-          onChange={field.onChange}
+          onChange={props.onChange ? props.onChange : field.onChange}
         />
         {props.variant === "currency" ? (
           <span className="dollar-sign">$</span>

--- a/src/common/components/text-input/TextInput.tsx
+++ b/src/common/components/text-input/TextInput.tsx
@@ -22,7 +22,10 @@ const _TextInput: ForwardRefRenderFunction<HTMLInputElement, Props> = (
   props,
   externalRef
 ) => {
-  const { field, fieldState } = useController(props);
+  const {
+    field,
+    // fieldState
+  } = useController(props);
   // console.log(fieldState);
   return (
     <StyledInput className="TextInput">

--- a/src/common/components/text-input/TextInput.tsx
+++ b/src/common/components/text-input/TextInput.tsx
@@ -23,7 +23,7 @@ const _TextInput: ForwardRefRenderFunction<HTMLInputElement, Props> = (
   externalRef
 ) => {
   const { field, fieldState } = useController(props);
-  console.log(fieldState);
+  // console.log(fieldState);
   return (
     <StyledInput className="TextInput">
       <label className="label">{props.label}</label>

--- a/src/common/components/text-input/TextInput.tsx
+++ b/src/common/components/text-input/TextInput.tsx
@@ -15,14 +15,15 @@ interface Props {
   label?: string;
   placeholder?: string;
   onChange?: ChangeEventHandler<HTMLInputElement>;
+  rules?: { pattern: RegExp };
 }
 
 const _TextInput: ForwardRefRenderFunction<HTMLInputElement, Props> = (
   props,
   externalRef
 ) => {
-  const { field } = useController(props);
-
+  const { field, fieldState } = useController(props);
+  console.log(fieldState);
   return (
     <StyledInput className="TextInput">
       <label className="label">{props.label}</label>

--- a/src/common/components/text-input/TextInput.tsx
+++ b/src/common/components/text-input/TextInput.tsx
@@ -36,7 +36,7 @@ const _TextInput: ForwardRefRenderFunction<HTMLInputElement, Props> = (
           placeholder={props.placeholder}
           ref={field.ref}
           value={field.value}
-          onChange={props.onChange ? props.onChange : field.onChange}
+          onChange={props.onChange ?? field.onChange}
         />
         {props.variant === "currency" ? (
           <span className="dollar-sign">$</span>

--- a/src/common/components/text-input/TextInput.tsx
+++ b/src/common/components/text-input/TextInput.tsx
@@ -26,7 +26,7 @@ const _TextInput: ForwardRefRenderFunction<HTMLInputElement, Props> = (
     field,
     // fieldState
   } = useController(props);
-  // console.log(fieldState);
+
   return (
     <StyledInput className="TextInput">
       <label className="label">{props.label}</label>

--- a/src/common/hooks/useVoteData.ts
+++ b/src/common/hooks/useVoteData.ts
@@ -60,6 +60,10 @@ function useVoteData() {
   const { loading, error, data, refetch } = useQuery<{
     priceRequestRounds: PriceRequestRound[];
   }>(PRICE_REQUEST_VOTING_DATA, {
+    variables: {
+      orderBy: "time",
+      orderDirection: "desc",
+    },
     pollInterval: POLLING_INTERVAL,
   });
 
@@ -70,6 +74,7 @@ function useVoteData() {
     }
 
     if (!loading && data) {
+      console.log("data", data);
       const newVoteSummaryData = formatPriceRequestVoteData(
         data.priceRequestRounds
       );

--- a/src/common/hooks/useVoteData.ts
+++ b/src/common/hooks/useVoteData.ts
@@ -73,6 +73,7 @@ function useVoteData() {
       const newVoteSummaryData = formatPriceRequestVoteData(
         data.priceRequestRounds
       );
+      console.log("newVoteSummaryData", newVoteSummaryData);
       setVotingSummaryData(newVoteSummaryData);
     }
   }, [loading, error, data]);

--- a/src/common/hooks/useVoteData.ts
+++ b/src/common/hooks/useVoteData.ts
@@ -74,11 +74,9 @@ function useVoteData() {
     }
 
     if (!loading && data) {
-      console.log("data", data);
       const newVoteSummaryData = formatPriceRequestVoteData(
         data.priceRequestRounds
       );
-      console.log("newVoteSummaryData", newVoteSummaryData);
       setVotingSummaryData(newVoteSummaryData);
     }
   }, [loading, error, data]);

--- a/src/features/vote/ActiveRequests.tsx
+++ b/src/features/vote/ActiveRequests.tsx
@@ -16,6 +16,7 @@ import ActiveViewDetailsModal from "./ActiveViewDetailsModal";
 import useModal from "common/hooks/useModal";
 import { SigningKeys } from "App";
 import { Round } from "web3/get/queryRounds";
+import { RefetchOptions, QueryObserverResult } from "react-query";
 
 export interface ModalState {
   proposal: string;
@@ -26,7 +27,9 @@ export interface ModalState {
 interface Props {
   activeRequests: PendingRequest[];
   roundId: string;
-  refetchRoundId: Function;
+  refetchRoundId: (
+    options?: RefetchOptions | undefined
+  ) => Promise<QueryObserverResult<string | void | undefined, unknown>>;
   encryptedVotes: EncryptedVote[];
   refetchEncryptedVotes: Function;
   revealedVotes: VoteRevealed[];

--- a/src/features/vote/ActiveRequests.tsx
+++ b/src/features/vote/ActiveRequests.tsx
@@ -26,6 +26,7 @@ export interface ModalState {
 interface Props {
   activeRequests: PendingRequest[];
   roundId: string;
+  refetchRoundId: Function;
   encryptedVotes: EncryptedVote[];
   refetchEncryptedVotes: Function;
   revealedVotes: VoteRevealed[];
@@ -45,6 +46,7 @@ const ActiveRequests: FC<Props> = ({
   hotAddress,
   signingKeys,
   refetchVoteRevealedEvents,
+  refetchRoundId,
 }) => {
   const [timeRemaining, setTimeRemaining] = useState("00:00");
 
@@ -134,6 +136,7 @@ const ActiveRequests: FC<Props> = ({
           refetchVoteRevealedEvents={refetchVoteRevealedEvents}
           setViewDetailsModalState={setModalState}
           openViewDetailsModal={open}
+          refetchRoundId={refetchRoundId}
         />
       ) : null}
       <ActiveViewDetailsModal

--- a/src/features/vote/CommitPhase.tsx
+++ b/src/features/vote/CommitPhase.tsx
@@ -70,6 +70,7 @@ const CommitPhase: FC<Props> = ({
 }) => {
   const [modalState, setModalState] = useState<SubmitModalState>("init");
   const [submitErrorMessage, setSubmitErrorMessage] = useState("");
+  const [txHash, setTxHash] = useState("");
   const {
     state: { network, signer, notify },
   } = useContext(OnboardContext);
@@ -112,6 +113,11 @@ const CommitPhase: FC<Props> = ({
     }
   }, [isConnected, reset, close]);
 
+  // remove tx hash if modal is closed.
+  useEffect(() => {
+    if (!isOpen && txHash) setTxHash("");
+  }, [isOpen, txHash]);
+
   const onSubmit = useCallback(
     (data: FormData) => {
       const validValues = {} as FormData;
@@ -145,6 +151,8 @@ const CommitPhase: FC<Props> = ({
                 // Need to confirm if the user submits the vote.
                 assert(tx, "Transaction did not get submitted, try again");
                 if (tx) {
+                  console.log("tx", tx);
+                  setTxHash(tx.hash);
                   if (notify) notify.hash(tx.hash);
 
                   tx.wait(1)
@@ -383,6 +391,7 @@ const CommitPhase: FC<Props> = ({
         onSubmit={onSubmit}
         submitErrorMessage={submitErrorMessage}
         setSubmitErrorMessage={setSubmitErrorMessage}
+        txHash={txHash}
       />
     </FormWrapper>
   );

--- a/src/features/vote/CommitPhase.tsx
+++ b/src/features/vote/CommitPhase.tsx
@@ -150,24 +150,21 @@ const CommitPhase: FC<Props> = ({
 
                 // Need to confirm if the user submits the vote.
                 assert(tx, "Transaction did not get submitted, try again");
-                if (tx) {
-                  console.log("tx", tx);
-                  setTxHash(tx.hash);
-                  if (notify) notify.hash(tx.hash);
+                setTxHash(tx.hash);
+                if (notify) notify.hash(tx.hash);
 
-                  tx.wait(1)
-                    .then((conf: any) => {
-                      // Temporary, as mining is instant on local ganache.
-                      // setTimeout(() => setModalState("success"), 5000);
-                      setModalState("success");
-                      refetchEncryptedVotes();
-                      reset();
-                    })
-                    .catch((err: any) => {
-                      setSubmitErrorMessage("Error with tx.");
-                      setModalState("init");
-                    });
-                }
+                tx.wait(1)
+                  .then((conf: any) => {
+                    // Temporary, as mining is instant on local ganache.
+                    // setTimeout(() => setModalState("success"), 5000);
+                    setModalState("success");
+                    refetchEncryptedVotes();
+                    reset();
+                  })
+                  .catch((err: any) => {
+                    setSubmitErrorMessage("Error with tx.");
+                    setModalState("init");
+                  });
               })
               .catch((err) => {
                 setSubmitErrorMessage(err.message);

--- a/src/features/vote/CommitPhase.tsx
+++ b/src/features/vote/CommitPhase.tsx
@@ -9,7 +9,7 @@ import {
   useEffect,
 } from "react";
 import assert from "assert";
-import { useForm } from "react-hook-form";
+import { useForm, Controller, ControllerRenderProps } from "react-hook-form";
 import { PendingRequest } from "web3/get/queryGetPendingRequests";
 import Button from "common/components/button";
 import TextInput from "common/components/text-input";
@@ -282,13 +282,31 @@ const CommitPhase: FC<Props> = ({
                       />
                     </div>
                   ) : (
-                    <TextInput
-                      label="Input your vote."
-                      control={control}
+                    <Controller
                       name={`${el.identifier}~${el.unix}~${el.ancHex}`}
-                      placeholder="0.000"
-                      variant="text"
+                      control={control}
+                      render={({ onChange }) => {
+                        return (
+                          <TextInput
+                            label="Input your vote."
+                            control={control}
+                            name={`${el.identifier}~${el.unix}~${el.ancHex}`}
+                            placeholder="0.000"
+                            variant="text"
+                            onChange={(e) => {
+                              onChange(e.target.value);
+                            }}
+                          />
+                        );
+                      }}
                     />
+                    // <TextInput
+                    //   label="Input your vote."
+                    //   control={control}
+                    //   name={`${el.identifier}~${el.unix}~${el.ancHex}`}
+                    //   placeholder="0.000"
+                    //   variant="text"
+                    // />
                   )}
                 </td>
 

--- a/src/features/vote/CommitPhase.tsx
+++ b/src/features/vote/CommitPhase.tsx
@@ -307,6 +307,8 @@ const CommitPhase: FC<Props> = ({
                               pattern: /^[-]?([0-9]*[.])?[0-9]+$/,
                             }}
                             // onChange={(e) => {
+                            /* WIP for another ticket. Ignore for now. */
+
                             //   const regexPattern =
                             //     /[-]?([0-9]+([.][0-9]*)?|[.][0-9]+)/;
                             //   // const rep = /^[-]?([0-9]*[.])?[0-9]+$/;
@@ -324,13 +326,6 @@ const CommitPhase: FC<Props> = ({
                         );
                       }}
                     />
-                    // <TextInput
-                    //   label="Input your vote."
-                    //   control={control}
-                    //   name={`${el.identifier}~${el.unix}~${el.ancHex}`}
-                    //   placeholder="0.000"
-                    //   variant="text"
-                    // />
                   )}
                 </td>
 

--- a/src/features/vote/CommitPhase.tsx
+++ b/src/features/vote/CommitPhase.tsx
@@ -9,7 +9,7 @@ import {
   useEffect,
 } from "react";
 import assert from "assert";
-import { useForm, Controller, ControllerRenderProps } from "react-hook-form";
+import { useForm, Controller } from "react-hook-form";
 import { PendingRequest } from "web3/get/queryGetPendingRequests";
 import Button from "common/components/button";
 import TextInput from "common/components/text-input";

--- a/src/features/vote/CommitPhase.tsx
+++ b/src/features/vote/CommitPhase.tsx
@@ -285,7 +285,9 @@ const CommitPhase: FC<Props> = ({
                     <Controller
                       name={`${el.identifier}~${el.unix}~${el.ancHex}`}
                       control={control}
-                      render={({ onChange }) => {
+                      rules={{ pattern: /^[-]?([0-9]*[.])?[0-9]+$/ }}
+                      render={({ field }) => {
+                        // console.log("meta.error", meta);
                         return (
                           <TextInput
                             label="Input your vote."
@@ -293,9 +295,23 @@ const CommitPhase: FC<Props> = ({
                             name={`${el.identifier}~${el.unix}~${el.ancHex}`}
                             placeholder="0.000"
                             variant="text"
-                            onChange={(e) => {
-                              onChange(e.target.value);
+                            rules={{
+                              pattern: /^[-]?([0-9]*[.])?[0-9]+$/,
                             }}
+                            // onChange={(e) => {
+                            //   const regexPattern =
+                            //     /[-]?([0-9]+([.][0-9]*)?|[.][0-9]+)/;
+                            //   // const rep = /^[-]?([0-9]*[.])?[0-9]+$/;
+                            //   // console.log(
+                            //   //   "testing value",
+                            //   //   regexPattern.test(e.target.value)
+                            //   // );
+                            //   // if (regexPattern.test(e.target.value)) {
+                            //   return onChange(e.target.value);
+                            //   // } else {
+                            //   // if
+                            //   // }
+                            // }}
                           />
                         );
                       }}

--- a/src/features/vote/PastRequests.tsx
+++ b/src/features/vote/PastRequests.tsx
@@ -65,8 +65,6 @@ const PastRequests: FC<Props> = ({
         (el) => Number(el.roundId) < Number(roundId)
       );
 
-      // console.log("FBR", filteredByRound, "raw data", voteSummaryData);
-
       if (address && contract) {
         const pr = formatPastRequestsByAddress(filteredByRound, address);
         setPastRequests(!showAll ? pr.slice(0, 10) : pr);

--- a/src/features/vote/PastRequests.tsx
+++ b/src/features/vote/PastRequests.tsx
@@ -65,6 +65,8 @@ const PastRequests: FC<Props> = ({
         (el) => Number(el.roundId) < Number(roundId)
       );
 
+      // console.log("FBR", filteredByRound, "raw data", voteSummaryData);
+
       if (address && contract) {
         const pr = formatPastRequestsByAddress(filteredByRound, address);
         setPastRequests(!showAll ? pr.slice(0, 10) : pr);

--- a/src/features/vote/PastViewDetailsModal.tsx
+++ b/src/features/vote/PastViewDetailsModal.tsx
@@ -106,7 +106,7 @@ const _PastViewDetailsModal: ForwardRefRenderFunction<
       >
         <ModalWrapper>
           <MiniHeader>Proposal</MiniHeader>
-          <Proposal>{isUmip ? umip?.title : proposal}</Proposal>
+          <Proposal>{isUmip && umip?.title ? umip.title : proposal}</Proposal>
 
           <Description>
             <ReactMarkdown

--- a/src/features/vote/PastViewDetailsModal.tsx
+++ b/src/features/vote/PastViewDetailsModal.tsx
@@ -27,6 +27,7 @@ import { DiscordRed } from "assets/icons";
 import { ethers } from "ethers";
 import useUMIP from "./useUMIP";
 import useOnboard from "common/hooks/useOnboard";
+import toWeiSafe from "common/utils/web3/convertToWeiSafely";
 
 interface Props {
   isOpen: boolean;
@@ -65,7 +66,8 @@ const _PastViewDetailsModal: ForwardRefRenderFunction<
   // Format rewards to 6 decs. It is a Big Num as it the value is in wei.
   useEffect(() => {
     if (rewardsClaimed !== "-" && rewardsClaimed !== "0") {
-      const formatRCArr = ethers.utils.formatEther(rewardsClaimed).split(".");
+      const rcToWei = toWeiSafe(rewardsClaimed).toString();
+      const formatRCArr = ethers.utils.formatEther(rcToWei).split(".");
       formatRCArr[1] = formatRCArr[1].substring(0, 6);
       const formatRC = formatRCArr.join(".");
       setFormattedRewardsClaimed(formatRC);

--- a/src/features/vote/PastViewDetailsModal.tsx
+++ b/src/features/vote/PastViewDetailsModal.tsx
@@ -66,7 +66,7 @@ const _PastViewDetailsModal: ForwardRefRenderFunction<
   // Format rewards to 6 decs. It is a Big Num as it the value is in wei.
   useEffect(() => {
     if (rewardsClaimed !== "-" && rewardsClaimed !== "0") {
-      const rcToWei = toWeiSafe(rewardsClaimed).toString();
+      const rcToWei = toWeiSafe(rewardsClaimed);
       const formatRCArr = ethers.utils.formatEther(rcToWei).split(".");
       formatRCArr[1] = formatRCArr[1].substring(0, 6);
       const formatRC = formatRCArr.join(".");

--- a/src/features/vote/RevealPhase.tsx
+++ b/src/features/vote/RevealPhase.tsx
@@ -28,6 +28,7 @@ interface Props {
   refetchVoteRevealedEvents: Function;
   setViewDetailsModalState: Dispatch<SetStateAction<ModalState>>;
   openViewDetailsModal: () => void;
+  refetchRoundId: Function;
 }
 
 const RevealPhase: FC<Props> = ({
@@ -42,6 +43,7 @@ const RevealPhase: FC<Props> = ({
   openViewDetailsModal,
   setViewDetailsModalState,
   refetchVoteRevealedEvents,
+  refetchRoundId,
 }) => {
   const { tableValues, postRevealData, setPostRevealData } = useTableValues(
     activeRequests,
@@ -152,6 +154,10 @@ const RevealPhase: FC<Props> = ({
                                 // TODO: Refetch state after snapshot.
                                 if (tx) {
                                   if (notify) notify.hash(tx.hash);
+                                  // Get roundID immediately to move snapshot on.
+                                  tx.wait(1).then(() => {
+                                    refetchRoundId();
+                                  });
                                 }
                               }
                             );

--- a/src/features/vote/RevealPhase.tsx
+++ b/src/features/vote/RevealPhase.tsx
@@ -15,6 +15,7 @@ import { VoteRevealed } from "web3/get/queryVotesRevealedEvents";
 import { ModalState } from "./ActiveRequests";
 import useTableValues from "./useTableValues";
 import { ErrorContext } from "common/context/ErrorContext";
+import { RefetchOptions, QueryObserverResult } from "react-query";
 
 interface Props {
   isConnected: boolean;
@@ -28,7 +29,9 @@ interface Props {
   refetchVoteRevealedEvents: Function;
   setViewDetailsModalState: Dispatch<SetStateAction<ModalState>>;
   openViewDetailsModal: () => void;
-  refetchRoundId: Function;
+  refetchRoundId: (
+    options?: RefetchOptions | undefined
+  ) => Promise<QueryObserverResult<string | void | undefined, unknown>>;
 }
 
 const RevealPhase: FC<Props> = ({

--- a/src/features/vote/RevealPhase.tsx
+++ b/src/features/vote/RevealPhase.tsx
@@ -121,7 +121,7 @@ const RevealPhase: FC<Props> = ({
                     ) : el.vote !== UNDEFINED_VOTE && !el.revealed ? (
                       <p>Reveal</p>
                     ) : el.vote === UNDEFINED_VOTE ? (
-                      <p>Uncommitted</p>
+                      <p>-</p>
                     ) : null}
                   </div>
                 </td>

--- a/src/features/vote/RevealPhase.tsx
+++ b/src/features/vote/RevealPhase.tsx
@@ -102,9 +102,6 @@ const RevealPhase: FC<Props> = ({
                   <div className="description">{el.description}</div>
                 </td>
                 <td>
-                  <div>{el.timestamp}</div>
-                </td>
-                <td>
                   <div>
                     {el.timestamp} ({el.unix})
                   </div>

--- a/src/features/vote/SubmitCommitsModal.tsx
+++ b/src/features/vote/SubmitCommitsModal.tsx
@@ -12,6 +12,7 @@ import Button from "common/components/button";
 import {
   ModalWrapper,
   SubmitErrorMessage,
+  EthTransaction,
 } from "./styled/SubmitCommitsModal.styled";
 import { SubmitModalState, Summary, FormData } from "./CommitPhase";
 import { UnlockedIcon, LockedIconCommitted } from "assets/icons";
@@ -39,6 +40,7 @@ interface Props {
     onInvalid?: SubmitErrorHandler<FormData>
   ) => (e?: BaseSyntheticEvent) => Promise<void>;
   onSubmit: (data: FormData) => void;
+  txHash: string;
 }
 
 const _SubmitCommitsModal: ForwardRefRenderFunction<
@@ -56,6 +58,7 @@ const _SubmitCommitsModal: ForwardRefRenderFunction<
     onSubmit,
     submitErrorMessage,
     setSubmitErrorMessage,
+    txHash,
   },
   externalRef
 ) => {
@@ -114,6 +117,23 @@ const _SubmitCommitsModal: ForwardRefRenderFunction<
                 );
               })
             : null}
+          {(modalState === "pending" || modalState === "success") &&
+          process.env.REACT_APP_CURRENT_ENV !== "test" ? (
+            <EthTransaction>
+              <a
+                href={
+                  process.env.REACT_APP_CURRENT_ENV === "kovan"
+                    ? `https://kovan.etherscan.io/tx/${txHash}`
+                    : `https://etherscan.io/tx/${txHash}`
+                }
+                target="_blank"
+                rel="noreferrer"
+              >
+                Click here
+              </a>{" "}
+              to view the transaction.
+            </EthTransaction>
+          ) : null}
           <div
             className={`button-wrapper ${
               modalState === "pending" ? "pending" : ""

--- a/src/features/vote/SubmitCommitsModal.tsx
+++ b/src/features/vote/SubmitCommitsModal.tsx
@@ -19,6 +19,7 @@ import {
   FieldValues,
   SubmitHandler,
   SubmitErrorHandler,
+  UseFormReset,
 } from "react-hook-form";
 
 interface Props {
@@ -31,24 +32,7 @@ interface Props {
   setSubmitErrorMessage: Dispatch<SetStateAction<string>>;
   showModalSummary: () => Summary[];
   // From react-hook-form
-  reset: (
-    values?:
-      | {
-          [x: string]: string | undefined;
-        }
-      | undefined,
-    omitResetState?:
-      | Partial<{
-          errors: boolean;
-          isDirty: boolean;
-          isSubmitted: boolean;
-          touched: boolean;
-          isValid: boolean;
-          submitCount: boolean;
-          dirtyFields: boolean;
-        }>
-      | undefined
-  ) => void;
+  reset: UseFormReset<FormData>;
   // From react hook form.
   handleSubmit: <TSubmitFieldValues extends FieldValues = FormData>(
     onValid: SubmitHandler<TSubmitFieldValues>,

--- a/src/features/vote/UpcomingRequests.tsx
+++ b/src/features/vote/UpcomingRequests.tsx
@@ -31,6 +31,7 @@ const UpcomingRequests: FC<Props> = ({ upcomingRequests }) => {
           year: "numeric",
           hour: "2-digit",
           minute: "2-digit",
+          second: "2-digit",
           hourCycle: "h24",
           timeZoneName: "short",
         });

--- a/src/features/vote/Vote.tsx
+++ b/src/features/vote/Vote.tsx
@@ -57,8 +57,7 @@ const Vote: FC<Props> = ({ signingKeys }) => {
     usePriceRequestAddedEvents();
   const { data: activeRequests = [] as PendingRequest[] } =
     usePendingRequests();
-  const { data: roundId = "" } = useCurrentRoundId();
-
+  const { data: roundId = "", refetch: refetchRoundId } = useCurrentRoundId();
 
   const {
     data: revealedVotes = [] as VoteRevealed[],
@@ -106,6 +105,7 @@ const Vote: FC<Props> = ({ signingKeys }) => {
           activeRequests={activeRequests}
           signingKeys={signingKeys}
           roundId={roundId}
+          refetchRoundId={refetchRoundId}
           encryptedVotes={encryptedVotes}
           refetchEncryptedVotes={refetchEncryptedVotes}
           revealedVotes={revealedVotes}

--- a/src/features/vote/helpers/formatPastRequestByAddress.ts
+++ b/src/features/vote/helpers/formatPastRequestByAddress.ts
@@ -9,7 +9,7 @@ export function formatPastRequestsByAddress(
   data: PriceRequestRound[],
   address: string
 ) {
-  const sortedByTime = data.slice().sort((a, b) => {
+  const sortedByTime = data.sort((a, b) => {
     if (Number(b.time) > Number(a.time)) return 1;
     if (Number(b.time) < Number(a.time)) return -1;
     return 0;

--- a/src/features/vote/styled/CommitPhase.styled.tsx
+++ b/src/features/vote/styled/CommitPhase.styled.tsx
@@ -70,6 +70,8 @@ export const FormWrapper = styled.form<StyledFormProps>`
         }
         th {
           padding-bottom: 1rem;
+          padding-left: 15px;
+          padding-right: 15px;
           border-bottom: 1px solid #e5e5e5;
         }
       }

--- a/src/features/vote/styled/CommitPhase.styled.tsx
+++ b/src/features/vote/styled/CommitPhase.styled.tsx
@@ -76,6 +76,9 @@ export const FormWrapper = styled.form<StyledFormProps>`
 
       tbody {
         td {
+          border-color: #fff;
+          border-style: solid;
+          border-width: 0 15px;
           div {
             display: flex;
           }

--- a/src/features/vote/styled/DetailModals.styled.tsx
+++ b/src/features/vote/styled/DetailModals.styled.tsx
@@ -17,6 +17,7 @@ export const ModalWrapper = styled.div`
   font-family: "Halyard Display";
   border: none;
   max-width: 700px;
+  max-height: 80vh;
   .header {
     text-align: center;
     margin-bottom: 1rem;

--- a/src/features/vote/styled/RevealPhase.styled.tsx
+++ b/src/features/vote/styled/RevealPhase.styled.tsx
@@ -48,9 +48,13 @@ export const Wrapper = styled.div<StyledProps>`
           opacity: ${(props) => (props.isConnected ? "1" : "0.5")};
         }
       }
-      select {
-      }
       thead {
+        th {
+          padding-bottom: 1rem;
+          padding-left: 15px;
+          padding-right: 15px;
+          border-bottom: 1px solid #e5e5e5;
+        }
         tr {
           text-align: left;
           margin-bottom: 2rem;

--- a/src/features/vote/styled/RevealPhase.styled.tsx
+++ b/src/features/vote/styled/RevealPhase.styled.tsx
@@ -59,6 +59,9 @@ export const Wrapper = styled.div<StyledProps>`
 
       tbody {
         td {
+          border-color: #fff;
+          border-style: solid;
+          border-width: 0 15px;
           div {
             display: flex;
             /* align-items: center; */

--- a/src/features/vote/styled/SubmitCommitsModal.styled.tsx
+++ b/src/features/vote/styled/SubmitCommitsModal.styled.tsx
@@ -6,6 +6,7 @@ export const ModalWrapper = styled.div`
   min-width: 400px;
   padding: 2rem 1.5rem;
   height: auto;
+  max-height: 80vh;
   position: relative;
   background-color: #fff;
   z-index: 1;

--- a/src/features/vote/styled/SubmitCommitsModal.styled.tsx
+++ b/src/features/vote/styled/SubmitCommitsModal.styled.tsx
@@ -153,3 +153,17 @@ export const SubmitErrorMessage = styled.div`
   margin: 0 auto;
   text-align: center;
 `;
+
+export const EthTransaction = styled.div`
+  margin: 1rem 0;
+  text-align: center;
+  color: #818180;
+  font-size: 0.8rem;
+
+  a {
+    text-decoration: underline;
+    &:hover {
+      color: #ff4a4a;
+    }
+  }
+`;

--- a/src/features/vote/useUMIP.ts
+++ b/src/features/vote/useUMIP.ts
@@ -22,6 +22,7 @@ export default function useUMIP(number?: number, chainId = 1) {
     () => fetchUmip(number!),
     {
       enabled: number != null && chainId === 1,
+      retry: 3,
     }
   );
 

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -174,11 +174,11 @@ const Wallet: FC<Props> = ({ signingKeys }) => {
             {isConnected && votingAddress ? (
               <>
                 <VotingAddress>
-                  {hotAddress ? "DVC: " : null} {shortenAddress(votingAddress)}
+                  {hotAddress ? "Vote: " : null} {shortenAddress(votingAddress)}
                 </VotingAddress>
                 {hotAddress ? (
                   <VotingAddress>
-                    Voting: {shortenAddress(hotAddress)}
+                    Hot: {shortenAddress(hotAddress)}
                   </VotingAddress>
                 ) : null}
                 {signingPK ? (

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -9,6 +9,7 @@ import { Settings } from "assets/icons";
 import getUmaBalance from "common/utils/web3/getUmaBalance";
 import useUmaPriceData from "common/hooks/useUmaPriceData";
 import usePrevious from "common/hooks/usePrevious";
+import ReactTooltip from "react-tooltip";
 
 import {
   useVotingAddress,
@@ -165,19 +166,28 @@ const Wallet: FC<Props> = ({ signingKeys }) => {
     signer,
   ]);
 
+  // Note: because there is dynamic content, this will rebuild the tooltip for addressing the conditional
+  // elements on the page. See ReactTooltip docs.
+  useEffect(() => {
+    ReactTooltip.rebuild();
+  });
+
   return (
     <Wrapper>
       <div className="wrapper">
         <div tw="flex items-stretch items-center">
           <div tw="py-8 pl-5 flex-grow">
-            <p className="wallet-title">Voting Wallet</p>
+            <div className="wallet-title">Voting Wallet</div>
             {isConnected && votingAddress ? (
               <>
                 <VotingAddress>
-                  {hotAddress ? "Vote: " : null} {shortenAddress(votingAddress)}
+                  {hotAddress ? "Vote: " : null}{" "}
+                  <span data-for="wallet" data-tip={`${votingAddress}`}>
+                    {shortenAddress(votingAddress)}
+                  </span>
                 </VotingAddress>
                 {hotAddress ? (
-                  <VotingAddress>
+                  <VotingAddress data-for="wallet" data-tip={`${hotAddress}`}>
                     Hot: {shortenAddress(hotAddress)}
                   </VotingAddress>
                 ) : null}
@@ -345,6 +355,7 @@ const Wallet: FC<Props> = ({ signingKeys }) => {
           signer={signer}
         />
       </div>
+      <ReactTooltip id="wallet" place="top" type="dark" effect="float" />
     </Wrapper>
   );
 };

--- a/src/features/wallet/styled/Wallet.styled.tsx
+++ b/src/features/wallet/styled/Wallet.styled.tsx
@@ -82,4 +82,5 @@ export const VotingAddress = styled.div`
   flex-basis: 1;
   color: #000;
   margin-left: 8px;
+  cursor: pointer;
 `;

--- a/src/hooks/useEncryptedVotesEvents.ts
+++ b/src/hooks/useEncryptedVotesEvents.ts
@@ -33,7 +33,11 @@ export default function useEncryptedVotesEvents(
     },
     {
       // do not run query if any of these are null
-      enabled: contract !== null && privateKey !== "" && address != null,
+      enabled:
+        contract !== null &&
+        privateKey !== "" &&
+        address != null &&
+        roundId !== "",
     }
   );
 

--- a/src/web3/get/queryEncryptedVotesEvents.ts
+++ b/src/web3/get/queryEncryptedVotesEvents.ts
@@ -78,14 +78,10 @@ export const queryEncryptedVotes = async (
         if (args) {
           let price = "";
           let salt = "";
-          try {
-            const json = JSON.parse(await decryptMessage(privateKey, args[5]));
-            price = json.price;
-            salt = json.salt;
-          } catch (err) {
-            // console.log("err in decript", err);
-            // return datum;
-          }
+
+          const json = JSON.parse(await decryptMessage(privateKey, args[5]));
+          price = json.price;
+          salt = json.salt;
 
           datum.address = args[0];
           datum.roundId = args[1].toString();

--- a/src/web3/get/queryEncryptedVotesEvents.ts
+++ b/src/web3/get/queryEncryptedVotesEvents.ts
@@ -78,9 +78,15 @@ export const queryEncryptedVotes = async (
         if (args) {
           let price = "";
           let salt = "";
-          const json = JSON.parse(await decryptMessage(privateKey, args[5]));
-          price = json.price;
-          salt = json.salt;
+          try {
+            const json = JSON.parse(await decryptMessage(privateKey, args[5]));
+            price = json.price;
+            salt = json.salt;
+          } catch (err) {
+            // console.log("err in decript", err);
+            // return datum;
+          }
+
           datum.address = args[0];
           datum.roundId = args[1].toString();
           datum.identifier = ethers.utils.toUtf8String(args[2]);

--- a/src/web3/get/queryRetrieveRewards.ts
+++ b/src/web3/get/queryRetrieveRewards.ts
@@ -33,6 +33,7 @@ export const queryRetrieveRewards = async (
 
     return ethers.utils.formatEther(reward.toString());
   } catch (err) {
-    console.log("err", err);
+    // We would expect an error here if the reward is available but not unclaimed.
+    // console.log("err", err);
   }
 };

--- a/src/web3/get/queryRewardsRetrievedEvents.ts
+++ b/src/web3/get/queryRewardsRetrievedEvents.ts
@@ -79,7 +79,6 @@ export const queryRewardsRetrievedEvents = async (
     }
     return rewards;
   } catch (err) {
-    console.log("did it throw here");
     throw err;
   }
 };

--- a/src/web3/get/queryRewardsRetrievedEvents.ts
+++ b/src/web3/get/queryRewardsRetrievedEvents.ts
@@ -79,6 +79,7 @@ export const queryRewardsRetrievedEvents = async (
     }
     return rewards;
   } catch (err) {
+    console.log("did it throw here");
     throw err;
   }
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": "src",
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext", "es2019"],
+    "lib": ["dom", "dom.iterable", "esnext", "es2020"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -20630,10 +20630,10 @@ react-error-overlay@^6.0.9:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
-react-hook-form@7:
-  version "7.6.6"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.6.6.tgz#74cd999a9db972f7848663529acf54cc5a4a837d"
-  integrity sha512-vmvrp/foLeWV1+g0IADvXc5xoJj8UMBIlN8PqgmbCD70oGFcNkQPc2FGfqOoJr6oL0EHkCpLizXWDqYOz/mvjw==
+react-hook-form@^7:
+  version "7.6.8"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.6.8.tgz#d47308b04e98a2beed73059125bdff84412d8194"
+  integrity sha512-Ri+XImhd/2bY4rV+aME0ij3G1L3cyhAErlhKmhDkgJx3NjCNQ+5et2Y1qp87mSDIyZq5UOFtRm0tDXEaTP3DPw==
 
 react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20785,6 +20785,14 @@ react-toastify@^7.0.3:
   dependencies:
     clsx "^1.1.1"
 
+react-tooltip@^4.2.19:
+  version "4.2.19"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.2.19.tgz#a865fffdb62154c6079bcb273e238de6b3c57366"
+  integrity sha512-wF6h0a2nqX3UHw9aSoj77Tv/+/KIjRdb107otHtX+1wISad1QoLD+j5chrBDx7mjY1T4WKfrV2DN+iFCimdZOw==
+  dependencies:
+    prop-types "^15.7.2"
+    uuid "^7.0.3"
+
 react@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
@@ -24447,6 +24455,11 @@ uuid@^3.1.0, uuid@^3.3.2, uuid@^3.3.3, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
+  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
 uuidv4@6.0.6:
   version "6.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20630,10 +20630,10 @@ react-error-overlay@^6.0.9:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
-react-hook-form@^6.15.5:
-  version "6.15.5"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.15.5.tgz#c2578f9ce6a6df7b33015587d40cd880dc13e2db"
-  integrity sha512-so2jEPYKdVk1olMo+HQ9D9n1hVzaPPFO4wsjgSeZ964R7q7CHsYRbVF0PGBi83FcycA5482WHflasdwLIUVENg==
+react-hook-form@7:
+  version "7.6.6"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.6.6.tgz#74cd999a9db972f7848663529acf54cc5a4a837d"
+  integrity sha512-vmvrp/foLeWV1+g0IADvXc5xoJj8UMBIlN8PqgmbCD70oGFcNkQPc2FGfqOoJr6oL0EHkCpLizXWDqYOz/mvjw==
 
 react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"


### PR DESCRIPTION
**Motivation**
Address issues reported by last voting round.

**Summary**
Following tickets were addressed:

1) Nav bar should highlight the page the user is on. (https://app.clubhouse.io/uma-project/story/978/nav-bar-should-highlight-the-page-the-user-is-on)

2) When a tx is submitted the commit/reveal module does not show a link to the successful tx (note this will only work on Kovan or mainnet). (https://app.clubhouse.io/uma-project/story/824/when-a-tx-is-submitted-the-commit-reveal-module-does-not-show-a-link-to-the-successful-tx)

3) If you click "view details" on a "Past Request" the dapp crashes. This was a float issue with ethers Big number.
 (https://app.clubhouse.io/uma-project/story/973/if-you-click-view-details-on-a-past-request-the-dapp-crashes

4) Dropdown chevron should be under the selected dropdown not over (https://app.clubhouse.io/uma-project/story/979/dropdown-chevron-should-be-under-the-selected-dropdown-not-over)

5) I can’t see the “yes I’m ready” button unless i zoom out past 80%. We should make the module viewable at 100%. I adjusted the height of the portal to use percentage, not raw pixels. (https://app.clubhouse.io/uma-project/story/949/i-can-t-see-the-yes-i-m-ready-button-unless-i-zoom-out-past-80-we-should-make-the-module-viewable-at-100)

6) Fix table spacing (https://app.clubhouse.io/uma-project/story/981/fix-table-spacing)

7) Incomplete past requests displaying. This was the result of the gql query not only returning 100 values. Set to 1000. (https://app.clubhouse.io/uma-project/story/988/incomplete-past-requests-displaying)

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested