### PR TITLE
Feat: signing keys stored in local storage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,7 +61,7 @@ function App(props: Props) {
 
               const updatedKeys = {
                 ...keys,
-                [hashedMessage]: { [address]: key },
+                [hashedMessage]: { ...keys[hashedMessage], [address]: key },
               };
 
               localStorage.setItem(
@@ -100,6 +100,8 @@ function App(props: Props) {
             addError(error);
           });
       }
+    } else {
+      setSigningKeys({});
     }
   }, [state.signer, state.address, addError, currentRoundId]);
 
@@ -128,6 +130,7 @@ function App(props: Props) {
       state.network &&
       state.network.chainId !== previousNetwork.chainId
     ) {
+      debugger;
       window.location.reload();
     }
   }, [state.network, previousNetwork]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -130,7 +130,6 @@ function App(props: Props) {
       state.network &&
       state.network.chainId !== previousNetwork.chainId
     ) {
-      debugger;
       window.location.reload();
     }
   }, [state.network, previousNetwork]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,8 +81,14 @@ function App(props: Props) {
     [addError]
   );
 
+  const previousRoundId = usePrevious(currentRoundId);
   useEffect(() => {
-    if (state.signer && state.address && currentRoundId && addError) {
+    if (
+      state.signer &&
+      state.address &&
+      currentRoundId &&
+      currentRoundId !== previousRoundId
+    ) {
       const address = state.address;
       const hashedMessage = currentSigningMessage(
         Number(currentRoundId)
@@ -96,17 +102,24 @@ function App(props: Props) {
         if (!keyExists) {
           signMessage(keys, state.address, state.signer, currentRoundId);
         } else {
-          console.log("here thrice");
           setSigningKeys(keys);
         }
       } catch (err) {
         const keys = {} as SigningKeys;
         signMessage(keys, state.address, state.signer, currentRoundId);
       }
-    } else {
+    }
+    if (!state.address || !state.signer) {
       setSigningKeys({});
     }
-  }, [state.signer, state.address, addError, currentRoundId, signMessage]);
+  }, [
+    state.signer,
+    state.address,
+    addError,
+    currentRoundId,
+    signMessage,
+    previousRoundId,
+  ]);
 
   useEffect(() => {
     if (error)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useState, useCallback } from "react";
 import Router from "features/router";
 import { QueryClient } from "react-query";
 import usePrevious from "common/hooks/usePrevious";
@@ -39,11 +39,43 @@ function App(props: Props) {
   const { error, removeError, addError } = useContext(ErrorContext);
   const { data: currentRoundId } = useCurrentRoundId();
 
+  // const signMessage = useCallback(() => {
+  //   state.signer
+  //   .signMessage(message)
+  //   .then((msg) => {
+  //     const key = {} as { publicKey: string; privateKey: string };
+
+  //     const privateKey = derivePrivateKey(msg);
+  //     const publicKey = recoverPublicKey(privateKey);
+  //     key.privateKey = privateKey;
+  //     key.publicKey = publicKey;
+
+  //     const updatedKeys = {
+  //       ...keys,
+  //       [hashedMessage]: { ...keys[hashedMessage], [address]: key },
+  //     };
+
+  //     localStorage.setItem(
+  //       SIGNING_KEYS_STORAGE_KEY,
+  //       JSON.stringify(updatedKeys)
+  //     );
+
+  //     setSigningKeys(updatedKeys);
+  //   })
+  //   .catch((err) => {
+  //     const error = new Error("Sign failed.");
+  //     addError(error);
+  //   });
+  // }, []);
+
   useEffect(() => {
     if (state.signer && state.address) {
       const address = state.address;
-      const message = currentSigningMessage(Number(currentRoundId));
-      const hashedMessage = web3.utils.utf8ToHex(message);
+      const message = currentSigningMessage(Number(currentRoundId)).message;
+      const hashedMessage = currentSigningMessage(
+        Number(currentRoundId)
+      ).hashedMessage;
+
       const keysString = localStorage.getItem(SIGNING_KEYS_STORAGE_KEY);
       if (keysString) {
         const keys = JSON.parse(keysString) as SigningKeys;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,12 @@ function App(props: Props) {
   const { data: currentRoundId } = useCurrentRoundId();
 
   const signMessage = useCallback(
-    (keys: SigningKeys, address: string, signer: ethers.Signer) => {
+    (
+      keys: SigningKeys,
+      address: string,
+      signer: ethers.Signer,
+      currentRoundId: string
+    ) => {
       const message = currentSigningMessage(Number(currentRoundId)).message;
       const hashedMessage = currentSigningMessage(
         Number(currentRoundId)
@@ -73,7 +78,7 @@ function App(props: Props) {
           addError(error);
         });
     },
-    []
+    [addError]
   );
 
   useEffect(() => {
@@ -89,19 +94,19 @@ function App(props: Props) {
         const keys = JSON.parse(keysString) as SigningKeys;
         const keyExists = keys[hashedMessage][address];
         if (!keyExists) {
-          signMessage(keys, state.address, state.signer);
+          signMessage(keys, state.address, state.signer, currentRoundId);
         } else {
           console.log("here thrice");
           setSigningKeys(keys);
         }
       } catch (err) {
         const keys = {} as SigningKeys;
-        signMessage(keys, state.address, state.signer);
+        signMessage(keys, state.address, state.signer, currentRoundId);
       }
     } else {
       setSigningKeys({});
     }
-  }, [state.signer, state.address, addError, currentRoundId]);
+  }, [state.signer, state.address, addError, currentRoundId, signMessage]);
 
   useEffect(() => {
     if (error)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import Router from "features/router";
 import { QueryClient } from "react-query";
 import usePrevious from "common/hooks/usePrevious";
 import { ToastContainer, toast } from "react-toastify";
-import { ethers } from "ethers";
+import web3 from "web3";
 
 // Context
 import { ErrorContext } from "common/context/ErrorContext";
@@ -43,7 +43,7 @@ function App(props: Props) {
     if (state.signer && state.address) {
       const address = state.address;
       const message = currentSigningMessage(Number(currentRoundId));
-      const hashedMessage = ethers.utils.formatBytes32String(message);
+      const hashedMessage = web3.utils.utf8ToHex(message);
       const keysString = localStorage.getItem(SIGNING_KEYS_STORAGE_KEY);
       if (keysString) {
         const keys = JSON.parse(keysString) as SigningKeys;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,14 +20,14 @@ interface Props {
 }
 
 export interface SigningKey {
-  [key: string]: {
+  [address: string]: {
     publicKey: string;
     privateKey: string;
   };
 }
 
 export interface SigningKeys {
-  [key: string]: SigningKey;
+  [signingString: string]: SigningKey;
 }
 
 const SIGNING_KEYS_STORAGE_KEY = "signingKeys";

--- a/src/common/context/OnboardContext.tsx
+++ b/src/common/context/OnboardContext.tsx
@@ -171,6 +171,7 @@ const connect = async (
 const disconnect = (dispatch: OnboardDispatch, onboard: OnboardApi | null) => {
   onboard?.walletReset();
   dispatch({ type: actions.RESET_STATE });
+  console.log("do we get to this part of disconnect");
 };
 
 export type Connect = typeof connect;

--- a/src/common/context/OnboardContext.tsx
+++ b/src/common/context/OnboardContext.tsx
@@ -171,7 +171,6 @@ const connect = async (
 const disconnect = (dispatch: OnboardDispatch, onboard: OnboardApi | null) => {
   onboard?.walletReset();
   dispatch({ type: actions.RESET_STATE });
-  console.log("do we get to this part of disconnect");
 };
 
 export type Connect = typeof connect;

--- a/src/common/currentSigningMessage.ts
+++ b/src/common/currentSigningMessage.ts
@@ -1,3 +1,5 @@
+import web3 from "web3";
+
 export default function currentSigningMessage(currentRound: number) {
   /*
     Whenever we change the signing message, we should wait until the next round.
@@ -5,9 +7,18 @@ export default function currentSigningMessage(currentRound: number) {
     it will only apply to the next, to prevent any bugs in revealing.
     There shouldn't be many reasons for us to change this, this is just to prevent any bugs in the commit -> reveal in a given round.
   */
-  if (currentRound > SIGNING_MESSAGE_ONE_ROUND_CREATED)
-    return SIGNING_MESSAGE_ONE;
-  return SIGNING_MESSAGE_ONE;
+  if (currentRound > SIGNING_MESSAGE_ONE_ROUND_CREATED) {
+    return {
+      message: SIGNING_MESSAGE_ONE,
+      hashedMessage: web3.utils.utf8ToHex(SIGNING_MESSAGE_ONE),
+    };
+  }
+
+  // Default return
+  return {
+    message: SIGNING_MESSAGE_ONE,
+    hashedMessage: web3.utils.utf8ToHex(SIGNING_MESSAGE_ONE),
+  };
 }
 
 const SIGNING_MESSAGE_ONE = "Login to UMA Voter dApp - 0";

--- a/src/common/currentSigningMessage.ts
+++ b/src/common/currentSigningMessage.ts
@@ -1,0 +1,3 @@
+export default function currentSigningMessage() {
+  return "";
+}

--- a/src/common/currentSigningMessage.ts
+++ b/src/common/currentSigningMessage.ts
@@ -1,3 +1,14 @@
-export default function currentSigningMessage() {
-  return "";
+export default function currentSigningMessage(currentRound: number) {
+  /*
+    Whenever we change the signing message, we should wait until the next round.
+    Determine current round, then create a conditional such that if we change the message in the middle of the round, 
+    it will only apply to the next, to prevent any bugs in revealing.
+    There shouldn't be many reasons for us to change this, this is just to prevent any bugs in the commit -> reveal in a given round.
+  */
+  if (currentRound > SIGNING_MESSAGE_ONE_ROUND_CREATED)
+    return SIGNING_MESSAGE_ONE;
+  return SIGNING_MESSAGE_ONE;
 }
+
+const SIGNING_MESSAGE_ONE = "Login to UMA Voter dApp - 0";
+const SIGNING_MESSAGE_ONE_ROUND_CREATED = 0;

--- a/src/common/helpers/getSigningKeys.ts
+++ b/src/common/helpers/getSigningKeys.ts
@@ -16,7 +16,7 @@ export default function getSigningKeys(
       keys.privateKey = signingKeys[hashedMessage][hotAddress]
         ? signingKeys[hashedMessage][hotAddress].privateKey
         : "";
-      keys.publicKey = signingKeys[hashedMessage][hotAddress].publicKey
+      keys.publicKey = signingKeys[hashedMessage][hotAddress]
         ? signingKeys[hashedMessage][hotAddress].publicKey
         : "";
     } else {

--- a/src/common/helpers/getSigningKeys.ts
+++ b/src/common/helpers/getSigningKeys.ts
@@ -1,0 +1,33 @@
+import { SigningKeys } from "App";
+
+export default function getSigningKeys(
+  signingKeys: SigningKeys,
+  hashedMessage: string,
+  votingAddress: string | null,
+  hotAddress: string | null
+) {
+  const keys = {
+    publicKey: "",
+    privateKey: "",
+  };
+
+  if (hashedMessage && votingAddress && Object.keys(signingKeys).length) {
+    if (hotAddress) {
+      keys.privateKey = signingKeys[hashedMessage][hotAddress]
+        ? signingKeys[hashedMessage][hotAddress].privateKey
+        : "";
+      keys.publicKey = signingKeys[hashedMessage][hotAddress].publicKey
+        ? signingKeys[hashedMessage][hotAddress].publicKey
+        : "";
+    } else {
+      keys.privateKey = signingKeys[hashedMessage][votingAddress]
+        ? signingKeys[hashedMessage][votingAddress].privateKey
+        : "";
+      keys.publicKey = signingKeys[hashedMessage][votingAddress]
+        ? signingKeys[hashedMessage][votingAddress].publicKey
+        : "";
+    }
+  }
+
+  return keys;
+}

--- a/src/common/hooks/useOnboard.ts
+++ b/src/common/hooks/useOnboard.ts
@@ -52,13 +52,15 @@ export default function useOnboard() {
           dispatch({ type: actions.SET_ADDRESS, payload: addr });
         },
         network: async (networkId: any) => {
-          dispatch({
-            type: actions.SET_NETWORK,
-            payload: {
-              chainId: networkId,
-              name: getNetworkName(networkId as ChainId),
-            },
-          });
+          if (networkId) {
+            dispatch({
+              type: actions.SET_NETWORK,
+              payload: {
+                chainId: networkId,
+                name: getNetworkName(networkId as ChainId),
+              },
+            });
+          }
 
           // Notify.js doesn't work on ganache anyway (see: docs).
           // So don't bother initializing it on test.

--- a/src/features/vote/ActiveRequests.tsx
+++ b/src/features/vote/ActiveRequests.tsx
@@ -19,6 +19,7 @@ import { Round } from "web3/get/queryRounds";
 import { RefetchOptions, QueryObserverResult } from "react-query";
 import currentSigningMessage from "common/currentSigningMessage";
 import web3 from "web3";
+import getSigningKeys from "common/helpers/getSigningKeys";
 
 export interface ModalState {
   proposal: string;
@@ -89,16 +90,12 @@ const ActiveRequests: FC<Props> = ({
   const message = currentSigningMessage(Number(roundId));
   const hashedMessage = web3.utils.utf8ToHex(message);
 
-  const signingPublicKey =
-    hotAddress &&
-    signingKeys[hashedMessage] &&
-    signingKeys[hashedMessage][hotAddress]
-      ? signingKeys[hashedMessage][hotAddress].publicKey
-      : votingAddress &&
-        signingKeys[hashedMessage] &&
-        signingKeys[hashedMessage][votingAddress]
-      ? signingKeys[hashedMessage][votingAddress].publicKey
-      : "";
+  const signingPublicKey = getSigningKeys(
+    signingKeys,
+    hashedMessage,
+    votingAddress,
+    hotAddress
+  ).publicKey;
 
   return (
     <Wrapper className="ActiveRequests">

--- a/src/features/vote/ActiveRequests.tsx
+++ b/src/features/vote/ActiveRequests.tsx
@@ -17,8 +17,8 @@ import useModal from "common/hooks/useModal";
 import { SigningKeys } from "App";
 import { Round } from "web3/get/queryRounds";
 import { RefetchOptions, QueryObserverResult } from "react-query";
-import { ethers } from "ethers";
 import currentSigningMessage from "common/currentSigningMessage";
+import web3 from "web3";
 
 export interface ModalState {
   proposal: string;
@@ -87,7 +87,7 @@ const ActiveRequests: FC<Props> = ({
   }, []);
 
   const message = currentSigningMessage(Number(roundId));
-  const hashedMessage = ethers.utils.formatBytes32String(message);
+  const hashedMessage = web3.utils.utf8ToHex(message);
 
   const signingPublicKey =
     hotAddress &&

--- a/src/features/vote/ActiveRequests.tsx
+++ b/src/features/vote/ActiveRequests.tsx
@@ -18,7 +18,6 @@ import { SigningKeys } from "App";
 import { Round } from "web3/get/queryRounds";
 import { RefetchOptions, QueryObserverResult } from "react-query";
 import currentSigningMessage from "common/currentSigningMessage";
-import web3 from "web3";
 import getSigningKeys from "common/helpers/getSigningKeys";
 
 export interface ModalState {
@@ -87,8 +86,7 @@ const ActiveRequests: FC<Props> = ({
     return () => clearInterval(timer);
   }, []);
 
-  const message = currentSigningMessage(Number(roundId));
-  const hashedMessage = web3.utils.utf8ToHex(message);
+  const hashedMessage = currentSigningMessage(Number(roundId)).hashedMessage;
 
   const signingPublicKey = getSigningKeys(
     signingKeys,

--- a/src/features/vote/ActiveRequests.tsx
+++ b/src/features/vote/ActiveRequests.tsx
@@ -17,6 +17,8 @@ import useModal from "common/hooks/useModal";
 import { SigningKeys } from "App";
 import { Round } from "web3/get/queryRounds";
 import { RefetchOptions, QueryObserverResult } from "react-query";
+import { ethers } from "ethers";
+import currentSigningMessage from "common/currentSigningMessage";
 
 export interface ModalState {
   proposal: string;
@@ -84,11 +86,18 @@ const ActiveRequests: FC<Props> = ({
     return () => clearInterval(timer);
   }, []);
 
+  const message = currentSigningMessage(Number(roundId));
+  const hashedMessage = ethers.utils.formatBytes32String(message);
+
   const signingPublicKey =
-    hotAddress && signingKeys[hotAddress]
-      ? signingKeys[hotAddress].publicKey
-      : votingAddress && signingKeys[votingAddress]
-      ? signingKeys[votingAddress].publicKey
+    hotAddress &&
+    signingKeys[hashedMessage] &&
+    signingKeys[hashedMessage][hotAddress]
+      ? signingKeys[hashedMessage][hotAddress].publicKey
+      : votingAddress &&
+        signingKeys[hashedMessage] &&
+        signingKeys[hashedMessage][votingAddress]
+      ? signingKeys[hashedMessage][votingAddress].publicKey
       : "";
 
   return (

--- a/src/features/vote/Vote.tsx
+++ b/src/features/vote/Vote.tsx
@@ -25,6 +25,8 @@ import { PendingRequest } from "web3/get/queryGetPendingRequests";
 import { VoteRevealed } from "web3/get/queryVotesRevealedEvents";
 import { EncryptedVote } from "web3/get/queryEncryptedVotesEvents";
 import { SigningKeys } from "App";
+import { ethers } from "ethers";
+import currentSigningMessage from "common/currentSigningMessage";
 
 interface Props {
   signingKeys: SigningKeys;
@@ -64,11 +66,18 @@ const Vote: FC<Props> = ({ signingKeys }) => {
     refetch: refetchVoteRevealedEvents,
   } = useVotesRevealedEvents(votingContract, votingAddress);
 
+  const message = currentSigningMessage(Number(roundId));
+  const hashedMessage = ethers.utils.formatBytes32String(message);
+
   const signingPK =
-    hotAddress && signingKeys[hotAddress]
-      ? signingKeys[hotAddress].privateKey
-      : votingAddress && signingKeys[votingAddress]
-      ? signingKeys[votingAddress].privateKey
+    hotAddress &&
+    signingKeys[hashedMessage] &&
+    signingKeys[hashedMessage][hotAddress]
+      ? signingKeys[hashedMessage][hotAddress].privateKey
+      : votingAddress &&
+        signingKeys[hashedMessage] &&
+        signingKeys[hashedMessage][votingAddress]
+      ? signingKeys[hashedMessage][votingAddress].privateKey
       : "";
 
   const {

--- a/src/features/vote/Vote.tsx
+++ b/src/features/vote/Vote.tsx
@@ -25,8 +25,8 @@ import { PendingRequest } from "web3/get/queryGetPendingRequests";
 import { VoteRevealed } from "web3/get/queryVotesRevealedEvents";
 import { EncryptedVote } from "web3/get/queryEncryptedVotesEvents";
 import { SigningKeys } from "App";
-import { ethers } from "ethers";
 import currentSigningMessage from "common/currentSigningMessage";
+import web3 from "web3";
 
 interface Props {
   signingKeys: SigningKeys;
@@ -67,7 +67,7 @@ const Vote: FC<Props> = ({ signingKeys }) => {
   } = useVotesRevealedEvents(votingContract, votingAddress);
 
   const message = currentSigningMessage(Number(roundId));
-  const hashedMessage = ethers.utils.formatBytes32String(message);
+  const hashedMessage = web3.utils.utf8ToHex(message);
 
   const signingPK =
     hotAddress &&

--- a/src/features/vote/Vote.tsx
+++ b/src/features/vote/Vote.tsx
@@ -26,7 +26,6 @@ import { VoteRevealed } from "web3/get/queryVotesRevealedEvents";
 import { EncryptedVote } from "web3/get/queryEncryptedVotesEvents";
 import { SigningKeys } from "App";
 import currentSigningMessage from "common/currentSigningMessage";
-import web3 from "web3";
 import getSigningKeys from "common/helpers/getSigningKeys";
 
 interface Props {
@@ -67,8 +66,7 @@ const Vote: FC<Props> = ({ signingKeys }) => {
     refetch: refetchVoteRevealedEvents,
   } = useVotesRevealedEvents(votingContract, votingAddress);
 
-  const message = currentSigningMessage(Number(roundId));
-  const hashedMessage = web3.utils.utf8ToHex(message);
+  const hashedMessage = currentSigningMessage(Number(roundId)).hashedMessage;
 
   const signingPK = getSigningKeys(
     signingKeys,

--- a/src/features/vote/Vote.tsx
+++ b/src/features/vote/Vote.tsx
@@ -27,6 +27,7 @@ import { EncryptedVote } from "web3/get/queryEncryptedVotesEvents";
 import { SigningKeys } from "App";
 import currentSigningMessage from "common/currentSigningMessage";
 import web3 from "web3";
+import getSigningKeys from "common/helpers/getSigningKeys";
 
 interface Props {
   signingKeys: SigningKeys;
@@ -69,16 +70,12 @@ const Vote: FC<Props> = ({ signingKeys }) => {
   const message = currentSigningMessage(Number(roundId));
   const hashedMessage = web3.utils.utf8ToHex(message);
 
-  const signingPK =
-    hotAddress &&
-    signingKeys[hashedMessage] &&
-    signingKeys[hashedMessage][hotAddress]
-      ? signingKeys[hashedMessage][hotAddress].privateKey
-      : votingAddress &&
-        signingKeys[hashedMessage] &&
-        signingKeys[hashedMessage][votingAddress]
-      ? signingKeys[hashedMessage][votingAddress].privateKey
-      : "";
+  const signingPK = getSigningKeys(
+    signingKeys,
+    hashedMessage,
+    votingAddress,
+    hotAddress
+  ).privateKey;
 
   const {
     data: encryptedVotes = [] as EncryptedVote[],

--- a/src/features/vote/styled/CommitPhase.styled.tsx
+++ b/src/features/vote/styled/CommitPhase.styled.tsx
@@ -78,6 +78,7 @@ export const FormWrapper = styled.form<StyledFormProps>`
 
       tbody {
         td {
+          vertical-align: baseline;
           border-color: #fff;
           border-style: solid;
           border-width: 0 15px;

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -39,6 +39,8 @@ import {
 } from "./styled/Wallet.styled";
 // import ERC20TransferButton from "./helpers/ERC20TransferButton";
 import { SigningKeys } from "App";
+import currentSigningMessage from "common/currentSigningMessage";
+import { useCurrentRoundId } from "hooks";
 
 interface Props {
   signingKeys: SigningKeys;
@@ -74,12 +76,20 @@ const Wallet: FC<Props> = ({ signingKeys }) => {
     signer,
     network
   );
+  const { data: roundId } = useCurrentRoundId();
+
+  const message = currentSigningMessage(Number(roundId));
+  const hashedMessage = ethers.utils.formatBytes32String(message);
 
   const signingPK =
-    hotAddress && signingKeys[hotAddress]
-      ? signingKeys[hotAddress].privateKey
-      : votingAddress && signingKeys[votingAddress]
-      ? signingKeys[votingAddress].privateKey
+    hotAddress &&
+    signingKeys[hashedMessage] &&
+    signingKeys[hashedMessage][hotAddress]
+      ? signingKeys[hashedMessage][hotAddress].privateKey
+      : votingAddress &&
+        signingKeys[hashedMessage] &&
+        signingKeys[hashedMessage][votingAddress]
+      ? signingKeys[hashedMessage][votingAddress].privateKey
       : "";
 
   const { votingContract, designatedVotingContract } = useVotingContract(

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -50,6 +50,7 @@ interface Props {
 const DEFAULT_BALANCE = "0";
 
 const Wallet: FC<Props> = ({ signingKeys }) => {
+  const [signingPK, setSigningPK] = useState("");
   const [umaBalance, setUmaBalance] = useState(DEFAULT_BALANCE);
   const [totalUmaCollected, setTotalUmaCollected] = useState(DEFAULT_BALANCE);
   const [availableRewards, setAvailableRewards] = useState(DEFAULT_BALANCE);
@@ -79,13 +80,22 @@ const Wallet: FC<Props> = ({ signingKeys }) => {
   );
   const { data: roundId } = useCurrentRoundId();
 
-  const hashedMessage = currentSigningMessage(Number(roundId)).hashedMessage;
-  const signingPK = getSigningKeys(
-    signingKeys,
-    hashedMessage,
-    votingAddress,
-    hotAddress
-  ).privateKey;
+  useEffect(() => {
+    if (Object.keys(signingKeys).length && votingAddress && roundId) {
+      const hashedMessage = currentSigningMessage(
+        Number(roundId)
+      ).hashedMessage;
+      const signingPK = getSigningKeys(
+        signingKeys,
+        hashedMessage,
+        votingAddress,
+        hotAddress
+      ).privateKey;
+      setSigningPK(signingPK);
+    } else {
+      setSigningPK("");
+    }
+  }, [signingKeys, roundId, votingAddress, hotAddress]);
 
   const { votingContract, designatedVotingContract } = useVotingContract(
     signer,

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -11,6 +11,7 @@ import getUmaBalance from "common/utils/web3/getUmaBalance";
 import useUmaPriceData from "common/hooks/useUmaPriceData";
 import usePrevious from "common/hooks/usePrevious";
 import ReactTooltip from "react-tooltip";
+import getSigningKeys from "common/helpers/getSigningKeys";
 
 import {
   useVotingAddress,
@@ -82,16 +83,12 @@ const Wallet: FC<Props> = ({ signingKeys }) => {
   const message = currentSigningMessage(Number(roundId));
   const hashedMessage = web3.utils.utf8ToHex(message);
 
-  const signingPK =
-    hotAddress &&
-    signingKeys[hashedMessage] &&
-    signingKeys[hashedMessage][hotAddress]
-      ? signingKeys[hashedMessage][hotAddress].privateKey
-      : votingAddress &&
-        signingKeys[hashedMessage] &&
-        signingKeys[hashedMessage][votingAddress]
-      ? signingKeys[hashedMessage][votingAddress].privateKey
-      : "";
+  const signingPK = getSigningKeys(
+    signingKeys,
+    hashedMessage,
+    votingAddress,
+    hotAddress
+  ).privateKey;
 
   const { votingContract, designatedVotingContract } = useVotingContract(
     signer,

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -2,6 +2,7 @@
 import { FC, useState, useEffect, useContext } from "react";
 import tw from "twin.macro"; // eslint-disable-line
 import { ethers } from "ethers";
+import web3 from "web3";
 import useModal from "common/hooks/useModal";
 import Button from "common/components/button";
 import useOnboard from "common/hooks/useOnboard";
@@ -79,7 +80,7 @@ const Wallet: FC<Props> = ({ signingKeys }) => {
   const { data: roundId } = useCurrentRoundId();
 
   const message = currentSigningMessage(Number(roundId));
-  const hashedMessage = ethers.utils.formatBytes32String(message);
+  const hashedMessage = web3.utils.utf8ToHex(message);
 
   const signingPK =
     hotAddress &&

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -50,7 +50,6 @@ interface Props {
 const DEFAULT_BALANCE = "0";
 
 const Wallet: FC<Props> = ({ signingKeys }) => {
-  const [signingPK, setSigningPK] = useState("");
   const [umaBalance, setUmaBalance] = useState(DEFAULT_BALANCE);
   const [totalUmaCollected, setTotalUmaCollected] = useState(DEFAULT_BALANCE);
   const [availableRewards, setAvailableRewards] = useState(DEFAULT_BALANCE);
@@ -79,23 +78,14 @@ const Wallet: FC<Props> = ({ signingKeys }) => {
     network
   );
   const { data: roundId } = useCurrentRoundId();
+  const hashedMessage = currentSigningMessage(Number(roundId)).hashedMessage;
 
-  useEffect(() => {
-    if (Object.keys(signingKeys).length && votingAddress && roundId) {
-      const hashedMessage = currentSigningMessage(
-        Number(roundId)
-      ).hashedMessage;
-      const signingPK = getSigningKeys(
-        signingKeys,
-        hashedMessage,
-        votingAddress,
-        hotAddress
-      ).privateKey;
-      setSigningPK(signingPK);
-    } else {
-      setSigningPK("");
-    }
-  }, [signingKeys, roundId, votingAddress, hotAddress]);
+  const signingPK = getSigningKeys(
+    signingKeys,
+    hashedMessage,
+    votingAddress,
+    hotAddress
+  ).privateKey;
 
   const { votingContract, designatedVotingContract } = useVotingContract(
     signer,

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -2,7 +2,6 @@
 import { FC, useState, useEffect, useContext } from "react";
 import tw from "twin.macro"; // eslint-disable-line
 import { ethers } from "ethers";
-import web3 from "web3";
 import useModal from "common/hooks/useModal";
 import Button from "common/components/button";
 import useOnboard from "common/hooks/useOnboard";
@@ -80,9 +79,7 @@ const Wallet: FC<Props> = ({ signingKeys }) => {
   );
   const { data: roundId } = useCurrentRoundId();
 
-  const message = currentSigningMessage(Number(roundId));
-  const hashedMessage = web3.utils.utf8ToHex(message);
-
+  const hashedMessage = currentSigningMessage(Number(roundId)).hashedMessage;
   const signingPK = getSigningKeys(
     signingKeys,
     hashedMessage,


### PR DESCRIPTION
Implementation of keeping signing keys in local storage so user should never have to resign unless we change the message.

https://app.clubhouse.io/uma-project/story/863/never-or-almost-never-need-to-re-sign-when-using-the-same-browser-on-the-same-machine