### PR TITLE
feat: add in unix and utc.

### DIFF
--- a/src/features/vote/CommitPhase.tsx
+++ b/src/features/vote/CommitPhase.tsx
@@ -243,7 +243,7 @@ const CommitPhase: FC<Props> = ({
           <tr>
             <th>Requested Vote</th>
             <th>Description</th>
-            <th>Timestamp</th>
+            <th>UNIX Timestamp</th>
             <th>Commit Vote</th>
             <th className="center-header">Vote Status</th>
           </tr>
@@ -275,9 +275,8 @@ const CommitPhase: FC<Props> = ({
                   <div className="description">{el.description}</div>
                 </td>
                 <td>
-                  <div>
-                    {el.timestamp} ({el.unix}){" "}
-                  </div>
+                  <div>{el.unix}</div>
+                  <div>({el.timestamp})</div>
                 </td>
                 <td className="input-cell">
                   {el.identifier.includes("Admin") ? (

--- a/src/features/vote/RevealPhase.tsx
+++ b/src/features/vote/RevealPhase.tsx
@@ -74,7 +74,7 @@ const RevealPhase: FC<Props> = ({
           <tr>
             <th>Requested Vote</th>
             <th>Description</th>
-            <th>Timestamp</th>
+            <th>UNIX Timestamp</th>
             <th className="center-header">Your Vote</th>
             <th className="center-header">Vote Status</th>
           </tr>
@@ -106,9 +106,8 @@ const RevealPhase: FC<Props> = ({
                   <div className="description">{el.description}</div>
                 </td>
                 <td>
-                  <div>
-                    {el.timestamp} ({el.unix})
-                  </div>
+                  <div>{el.unix}</div>
+                  <div>({el.timestamp})</div>
                 </td>
                 <td>
                   <div>


### PR DESCRIPTION
Added in unix and utc in the same column.

<img width="372" alt="Screen Shot 2021-06-04 at 12 03 43 PM" src="https://user-images.githubusercontent.com/12792146/120850914-f1bf2180-c52c-11eb-8aa0-77c093d933dd.png">


Signed-off-by: Tulun <jaykiraly@gmail.com>