### PR TITLE
Feat: Rewards wallet fixes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -111,8 +111,16 @@ function App(props: Props) {
   useEffect(() => {
     if (previousAddress && state.address && previousAddress !== state.address) {
       disconnect(dispatch, state.onboard);
+      props.queryClient.clear();
     }
-  }, [state.address, previousAddress, dispatch, state.onboard, disconnect]);
+  }, [
+    state.address,
+    previousAddress,
+    dispatch,
+    state.onboard,
+    disconnect,
+    props.queryClient,
+  ]);
 
   return (
     <div className="App">

--- a/src/features/router/Router.tsx
+++ b/src/features/router/Router.tsx
@@ -11,21 +11,31 @@ import Wallet from "features/wallet";
 import Footer from "common/components/footer";
 import { SigningKeys } from "App";
 
+import useVoteData, { PriceRequestRound } from "common/hooks/useVoteData";
+
 interface Props {
   signingKeys: SigningKeys;
 }
 
 const Router: FC<Props> = ({ signingKeys }) => {
+  const {
+    data: voteSummaryData = [] as PriceRequestRound[],
+    refetch: refetchVoteSummaryData,
+  } = useVoteData();
+
   return (
     <BrowserRouter>
       <div>
         <Navbar />
         {/* A <Switch> looks through its children <Route>s and
             renders the first one that matches the current URL. */}
-        <Wallet signingKeys={signingKeys} />
+        <Wallet
+          signingKeys={signingKeys}
+          refetchVoteSummaryData={refetchVoteSummaryData}
+        />
         <Switch>
           <Route path="/">
-            <Vote signingKeys={signingKeys} />
+            <Vote signingKeys={signingKeys} voteSummaryData={voteSummaryData} />
           </Route>
         </Switch>
       </div>

--- a/src/features/vote/RevealPhase.tsx
+++ b/src/features/vote/RevealPhase.tsx
@@ -1,4 +1,4 @@
-import { FC, useContext, Dispatch, SetStateAction } from "react";
+import { FC, useContext, useState, Dispatch, SetStateAction } from "react";
 import tw from "twin.macro"; // eslint-disable-line
 import web3 from "web3";
 import { Wrapper } from "./styled/RevealPhase.styled";
@@ -16,7 +16,15 @@ import { ModalState } from "./ActiveRequests";
 import useTableValues from "./useTableValues";
 import { ErrorContext } from "common/context/ErrorContext";
 import { RefetchOptions, QueryObserverResult } from "react-query";
-import { Description, Table, FullDate } from "./styled/ActiveRequests.styled";
+import useModal from "common/hooks/useModal";
+import DescriptionModal from "./DescriptionModal";
+
+import {
+  Description,
+  Table,
+  FullDate,
+  DescriptionWrapper,
+} from "./styled/ActiveRequests.styled";
 
 interface Props {
   isConnected: boolean;
@@ -53,6 +61,9 @@ const RevealPhase: FC<Props> = ({
   refetchRound,
   refetchRoundId,
 }) => {
+  const [description, setDescription] = useState("");
+  const [proposal, setProposal] = useState("");
+
   const { tableValues, postRevealData, setPostRevealData } = useTableValues(
     activeRequests,
     encryptedVotes,
@@ -71,6 +82,13 @@ const RevealPhase: FC<Props> = ({
     votingAddress,
     hotAddress
   );
+
+  const {
+    isOpen: descriptionIsOpen,
+    open: descriptionOpen,
+    close: descriptionClose,
+    modalRef: descriptionModalRef,
+  } = useModal();
 
   return (
     <Wrapper className="RequestPhase" isConnected={isConnected}>
@@ -108,16 +126,26 @@ const RevealPhase: FC<Props> = ({
                   </div>
                 </td>
                 <td>
-                  <div className="description">
-                    {el.description && el.description.split(" ").length > 16 ? (
+                  <DescriptionWrapper>
+                    {el.description && el.description.length > 255 ? (
                       <Description>
-                        {el.description.split(" ").slice(0, 16).join(" ")}...{" "}
-                        <span>Read More</span>{" "}
+                        {el.description.slice(0, 255)}...{" "}
+                        <span
+                          onClick={() => {
+                            setDescription(
+                              el.description || "Missing description"
+                            );
+                            setProposal(el.identifier);
+                            descriptionOpen();
+                          }}
+                        >
+                          Read More
+                        </span>{" "}
                       </Description>
                     ) : (
                       <Description>{el.description}</Description>
                     )}
-                  </div>
+                  </DescriptionWrapper>
                 </td>
                 <td>
                   <div>{el.unix}</div>
@@ -224,6 +252,15 @@ const RevealPhase: FC<Props> = ({
           ) : null}
         </div>
       </div>
+      <DescriptionModal
+        isOpen={descriptionIsOpen}
+        close={descriptionClose}
+        ref={descriptionModalRef}
+        description={description}
+        setDescription={setDescription}
+        proposal={proposal}
+        setProposal={setProposal}
+      />
     </Wrapper>
   );
 };

--- a/src/features/vote/Vote.tsx
+++ b/src/features/vote/Vote.tsx
@@ -7,7 +7,7 @@ import ActiveRequests from "./ActiveRequests";
 import PastRequests from "./PastRequests";
 import UpcomingRequests from "./UpcomingRequests";
 
-import useVoteData, { PriceRequestRound } from "common/hooks/useVoteData";
+import { PriceRequestRound } from "common/hooks/useVoteData";
 import { OnboardContext } from "common/context/OnboardContext";
 import {
   usePriceRequestAddedEvents,
@@ -27,16 +27,15 @@ import { SigningKeys } from "App";
 
 interface Props {
   signingKeys: SigningKeys;
+  voteSummaryData: PriceRequestRound[];
 }
 
-const Vote: FC<Props> = ({ signingKeys }) => {
+const Vote: FC<Props> = ({ signingKeys, voteSummaryData }) => {
   const [upcomingRequests, setUpcomingRequests] = useState<PriceRequestAdded[]>(
     []
   );
 
   const { state } = useContext(OnboardContext);
-
-  const { data: voteSummaryData = [] as PriceRequestRound[] } = useVoteData();
 
   const { votingAddress, hotAddress } = useVotingAddress(
     state.address,

--- a/src/features/vote/styled/RevealPhase.styled.tsx
+++ b/src/features/vote/styled/RevealPhase.styled.tsx
@@ -13,11 +13,14 @@ export const Wrapper = styled.div<StyledProps>`
       flex-direction: column;
       p:first-of-type {
         margin-bottom: 0.5rem;
+        font-size: 28px;
+        font-weight: 500;
       }
       .view-details {
         color: #ff4a4a;
         text-decoration: underline;
-        font-weight: 600;
+        font-weight: 500;
+        font-size: 14px;
         &:hover {
           cursor: pointer;
         }
@@ -32,6 +35,7 @@ export const Wrapper = styled.div<StyledProps>`
       text-align: center;
     }
     .end-row {
+      margin-top: 3rem;
       max-width: 1400px;
       margin-top: 1rem;
       margin-left: auto;

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -10,6 +10,7 @@ import getUmaBalance from "common/utils/web3/getUmaBalance";
 import useUmaPriceData from "common/hooks/useUmaPriceData";
 import usePrevious from "common/hooks/usePrevious";
 import ReactTooltip from "react-tooltip";
+import { OperationVariables, ApolloQueryResult } from "@apollo/client";
 
 import {
   useVotingAddress,
@@ -19,6 +20,7 @@ import {
   useMulticall,
   useCurrentRoundId,
 } from "hooks";
+import { PriceRequestRound } from "common/hooks/useVoteData";
 
 import TwoKeyContractModal from "./TwoKeyContractModal";
 import { ErrorContext } from "common/context/ErrorContext";
@@ -50,11 +52,18 @@ import { SigningKeys } from "App";
 
 interface Props {
   signingKeys: SigningKeys;
+  refetchVoteSummaryData: (
+    variables?: Partial<OperationVariables> | undefined
+  ) => Promise<
+    ApolloQueryResult<{
+      priceRequestRounds: PriceRequestRound[];
+    }>
+  >;
 }
 
 const DEFAULT_BALANCE = "0";
 
-const Wallet: FC<Props> = ({ signingKeys }) => {
+const Wallet: FC<Props> = ({ signingKeys, refetchVoteSummaryData }) => {
   const [umaBalance, setUmaBalance] = useState(DEFAULT_BALANCE);
   const [totalUmaCollected, setTotalUmaCollected] = useState(DEFAULT_BALANCE);
   const [availableRewards, setAvailableRewards] = useState(DEFAULT_BALANCE);
@@ -164,6 +173,8 @@ const Wallet: FC<Props> = ({ signingKeys }) => {
             setUmaBalance(balance);
           }
         );
+        // check to see if vote past data has changed.
+        refetchVoteSummaryData();
       }
     }
   }, [
@@ -174,6 +185,7 @@ const Wallet: FC<Props> = ({ signingKeys }) => {
     availableRewards,
     network,
     signer,
+    refetchVoteSummaryData,
   ]);
 
   // Note: because there is dynamic content, this will rebuild the tooltip for addressing the conditional

--- a/src/features/wallet/styled/Wallet.styled.tsx
+++ b/src/features/wallet/styled/Wallet.styled.tsx
@@ -32,9 +32,9 @@ export const Connected = styled.div`
   &::before {
     content: " ";
     display: inline-flex;
-    width: 6px;
-    height: 6px;
-    background-color: #ff4a4a;
+    width: 8px;
+    height: 8px;
+    background-color: #83cd90;
     border-radius: 50%;
     margin-right: 10px;
   }
@@ -42,8 +42,7 @@ export const Connected = styled.div`
 
 export const Disconnected = styled(Connected)`
   &::before {
-    background-color: #000;
-    opacity: 0.5;
+    background-color: #b3b2b2;
   }
 `;
 

--- a/src/hooks/useEncryptedVotesEvents.ts
+++ b/src/hooks/useEncryptedVotesEvents.ts
@@ -6,6 +6,7 @@ import {
   EncryptedVote,
 } from "web3/get/queryEncryptedVotesEvents";
 import { ErrorContext } from "common/context/ErrorContext";
+import usePrevious from "common/hooks/usePrevious";
 
 export default function useEncryptedVotesEvents(
   contract: ethers.Contract | null,
@@ -15,6 +16,12 @@ export default function useEncryptedVotesEvents(
 ) {
   const { addError } = useContext(ErrorContext);
 
+  const previousAddress = usePrevious(address);
+  // To prevent a "bad MAC" error, try not to run the query if the previousAddress is defined but it doesn't equal current address.
+  // This happens because the wallet state is async -- sometimes when disconnecting, address is defined before we change the state.
+  const addressCheck = !(
+    previousAddress !== null && previousAddress !== address
+  );
   const { data, error, isFetching, refetch } = useQuery<
     EncryptedVote[] | undefined | void
   >(
@@ -37,7 +44,8 @@ export default function useEncryptedVotesEvents(
         contract !== null &&
         privateKey !== "" &&
         address != null &&
-        roundId !== "",
+        roundId !== "" &&
+        addressCheck,
     }
   );
 


### PR DESCRIPTION
Following fixed:

1. Adjusted connected circle to be more centred and changed colour. ( https://app.clubhouse.io/uma-project/story/1387/center-status-button-for-wallet)
<img width="225" alt="Screen Shot 2021-06-17 at 4 05 17 PM" src="https://user-images.githubusercontent.com/12792146/122482674-d967f180-cf85-11eb-81ec-b05611024efd.png">
https://app.clubhouse.io/uma-project/story/1379/update-color-of-the-connected-with-metamask-indicator-to-green

2. More strict cond on the refetching of this data and clear cache on account change. (https://app.clubhouse.io/uma-project/story/1304/receiving-bad-mac-when-switching-between-wallets-in-top-right-corner)

3. Make a refetch of past requests when wallet balances change. (https://app.clubhouse.io/uma-project/story/1309/rewards-from-last-week-not-appearing-anywhere-in-ui)