### PR TITLE
Upgrade container size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     docker:
       - image: circleci/node:15.11.0
     working_directory: ~/voter-dapp
-    resource_class: medium+
+    resource_class: large
     steps:
       - checkout
       - run:


### PR DESCRIPTION
This PR try to fix that error:

```
<--- JS stacktrace --->

FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
 1: 0xa7f490 node::Abort() [/usr/local/bin/node]
 ```

Signed-off-by: uma-mining <contato@evaldofelipe.com>