### PR TITLE
feat: Commit seed backup

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "downshift": "^6.1.3",
     "ethers": "^5.0.32",
     "graphql": "^15.5.0",
-    "lodash": "^4.17.21",
+    "lodash.has": "^4.5.2",
+    "lodash.setwith": "^4.3.2",
     "luxon": "^1.26.0",
     "node-sass": "^5.0.0",
     "react": "^17.0.2",
@@ -79,6 +80,8 @@
   },
   "devDependencies": {
     "@types/crypto-js": "^4.0.1",
+    "@types/lodash.has": "^4.5.6",
+    "@types/lodash.setwith": "^4.3.6",
     "@types/luxon": "^1.26.2",
     "@types/react-router-dom": "^5.1.7",
     "cra-bundle-analyzer": "^0.1.0",

--- a/src/features/vote/ActiveRequests.tsx
+++ b/src/features/vote/ActiveRequests.tsx
@@ -175,6 +175,7 @@ const ActiveRequests: FC<Props> = ({
         committedVotes={committedVotes}
         revealedEvents={revealedEvents}
         roundId={roundId}
+        votingAddress={votingAddress}
       />
     </Wrapper>
   );

--- a/src/features/vote/ActiveViewDetailsModal.tsx
+++ b/src/features/vote/ActiveViewDetailsModal.tsx
@@ -80,6 +80,7 @@ const _ActiveViewDetailsModal: ForwardRefRenderFunction<
   const [revealPercentage, setRevealPercentage] = useState(NULL_PERCENTAGE);
   const [copySuccess, setCopySuccess] = useState(false);
   const [backupSeed, setBackupSeed] = useState("");
+
   // Note: because there is dynamic content, this will rebuild the tooltip for addressing the conditional
   // elements on the page. See ReactTooltip docs.
   useEffect(() => {
@@ -94,7 +95,6 @@ const _ActiveViewDetailsModal: ForwardRefRenderFunction<
       if (
         parsedJSON[votingAddress] &&
         parsedJSON[votingAddress][roundId] &&
-        parsedJSON[votingAddress][roundId] &&
         parsedJSON[votingAddress][roundId][uniqueIdentifier]
       ) {
         setBackupSeed(parsedJSON[votingAddress][roundId][uniqueIdentifier]);
@@ -102,7 +102,7 @@ const _ActiveViewDetailsModal: ForwardRefRenderFunction<
     } else {
       setBackupSeed("");
     }
-  }, [roundId, proposal, unix, votingAddress, ancData]);
+  }, [roundId, proposal, unix, votingAddress, ancData, committedVotes]);
 
   useEffect(() => {
     if (committedVotes && committedVotes.length && roundId && proposal) {

--- a/src/features/vote/ActiveViewDetailsModal.tsx
+++ b/src/features/vote/ActiveViewDetailsModal.tsx
@@ -33,6 +33,7 @@ import ReactTooltip from "react-tooltip";
 import web3 from "web3";
 import { VoteEvent } from "web3/types.web3";
 import { VoteRevealed } from "web3/get/queryVotesRevealedEvents";
+import has from "lodash.has";
 
 interface Props {
   isOpen: boolean;
@@ -93,9 +94,7 @@ const _ActiveViewDetailsModal: ForwardRefRenderFunction<
         const parsedJSON = JSON.parse(commits);
         const uniqueIdentifier = `${proposal}~${unix}~${ancData}`;
         if (
-          parsedJSON[votingAddress] &&
-          parsedJSON[votingAddress][roundId] &&
-          parsedJSON[votingAddress][roundId][uniqueIdentifier]
+          has(parsedJSON, `${votingAddress}.[${roundId}].${uniqueIdentifier}`)
         ) {
           setBackupSeed(parsedJSON[votingAddress][roundId][uniqueIdentifier]);
         }

--- a/src/features/vote/ActiveViewDetailsModal.tsx
+++ b/src/features/vote/ActiveViewDetailsModal.tsx
@@ -33,7 +33,6 @@ import ReactTooltip from "react-tooltip";
 import web3 from "web3";
 import { VoteEvent } from "web3/types.web3";
 import { VoteRevealed } from "web3/get/queryVotesRevealedEvents";
-// import {BackupCommit} from "./helpers/formatVoteDataToCommit"
 
 interface Props {
   isOpen: boolean;
@@ -90,14 +89,18 @@ const _ActiveViewDetailsModal: ForwardRefRenderFunction<
   useEffect(() => {
     const commits = localStorage.getItem("backupCommits");
     if (roundId && proposal && unix && votingAddress && commits && ancData) {
-      const parsedJSON = JSON.parse(commits);
-      const uniqueIdentifier = `${proposal}~${unix}~${ancData}`;
-      if (
-        parsedJSON[votingAddress] &&
-        parsedJSON[votingAddress][roundId] &&
-        parsedJSON[votingAddress][roundId][uniqueIdentifier]
-      ) {
-        setBackupSeed(parsedJSON[votingAddress][roundId][uniqueIdentifier]);
+      try {
+        const parsedJSON = JSON.parse(commits);
+        const uniqueIdentifier = `${proposal}~${unix}~${ancData}`;
+        if (
+          parsedJSON[votingAddress] &&
+          parsedJSON[votingAddress][roundId] &&
+          parsedJSON[votingAddress][roundId][uniqueIdentifier]
+        ) {
+          setBackupSeed(parsedJSON[votingAddress][roundId][uniqueIdentifier]);
+        }
+      } catch (err) {
+        setBackupSeed("");
       }
     } else {
       setBackupSeed("");

--- a/src/features/vote/ActiveViewDetailsModal.tsx
+++ b/src/features/vote/ActiveViewDetailsModal.tsx
@@ -33,6 +33,7 @@ import ReactTooltip from "react-tooltip";
 import web3 from "web3";
 import { VoteEvent } from "web3/types.web3";
 import { VoteRevealed } from "web3/get/queryVotesRevealedEvents";
+// import {BackupCommit} from "./helpers/formatVoteDataToCommit"
 
 interface Props {
   isOpen: boolean;
@@ -46,6 +47,7 @@ interface Props {
   committedVotes: VoteEvent[] | undefined | void;
   revealedEvents: VoteRevealed[] | undefined | void;
   roundId: string;
+  votingAddress: string | null;
 }
 
 const NULL_ANC_DATA = "0x";
@@ -67,6 +69,7 @@ const _ActiveViewDetailsModal: ForwardRefRenderFunction<
     committedVotes,
     revealedEvents,
     roundId,
+    votingAddress,
   },
   externalRef
 ) => {
@@ -76,11 +79,30 @@ const _ActiveViewDetailsModal: ForwardRefRenderFunction<
   const [numberRevealedAddresses, setNumberRevealedAddresses] = useState(0);
   const [revealPercentage, setRevealPercentage] = useState(NULL_PERCENTAGE);
   const [copySuccess, setCopySuccess] = useState(false);
+  const [backupSeed, setBackupSeed] = useState("");
   // Note: because there is dynamic content, this will rebuild the tooltip for addressing the conditional
   // elements on the page. See ReactTooltip docs.
   useEffect(() => {
     ReactTooltip.rebuild();
   });
+
+  useEffect(() => {
+    const commits = localStorage.getItem("backupCommits");
+    if (roundId && proposal && unix && votingAddress && commits && ancData) {
+      const parsedJSON = JSON.parse(commits);
+      const uniqueIdentifier = `${proposal}~${unix}~${ancData}`;
+      if (
+        parsedJSON[votingAddress] &&
+        parsedJSON[votingAddress][roundId] &&
+        parsedJSON[votingAddress][roundId] &&
+        parsedJSON[votingAddress][roundId][uniqueIdentifier]
+      ) {
+        setBackupSeed(parsedJSON[votingAddress][roundId][uniqueIdentifier]);
+      }
+    } else {
+      setBackupSeed("");
+    }
+  }, [roundId, proposal, unix, votingAddress, ancData]);
 
   useEffect(() => {
     if (committedVotes && committedVotes.length && roundId && proposal) {
@@ -250,11 +272,11 @@ const _ActiveViewDetailsModal: ForwardRefRenderFunction<
             {revealPercentage}% of Unique Commit Addresses
           </RevealPercentage>
           <MiniHeader>Proposal Timestamp</MiniHeader>
-          <LastStateValue
-            data-for="active-modal-timestamp"
-            data-tip={`UTC: ${unix}`}
-          >
-            {timestamp}
+          <LastStateValue>
+            <div data-for="active-modal-timestamp" data-tip={`UTC: ${unix}`}>
+              {timestamp}
+            </div>
+            {backupSeed && <div>Backup Commit Salt: {backupSeed}</div>}
           </LastStateValue>
         </ModalWrapper>
         <ReactTooltip

--- a/src/features/vote/CommitPhase.tsx
+++ b/src/features/vote/CommitPhase.tsx
@@ -80,8 +80,9 @@ const CommitPhase: FC<Props> = ({
   signingMessage,
 }) => {
   const [submitErrorMessage, setSubmitErrorMessage] = useState("");
-  const [buttonVariant, setButtonVariant] =
-    useState<"secondary" | "disabled">("disabled");
+  const [buttonVariant, setButtonVariant] = useState<"secondary" | "disabled">(
+    "disabled"
+  );
 
   const {
     state: { network, signer, notify },
@@ -167,8 +168,12 @@ const CommitPhase: FC<Props> = ({
           let vc = votingContract;
           if (designatedVotingContract) vc = designatedVotingContract;
           if (vc) {
-            commitVotes(vc, fd)
+            commitVotes(vc, fd.postValues)
               .then((tx) => {
+                localStorage.setItem(
+                  "backupCommits",
+                  JSON.stringify(fd.newCommits)
+                );
                 setSubmitErrorMessage("");
                 close();
                 reset();

--- a/src/features/vote/helpers/formatVoteDataToCommit.ts
+++ b/src/features/vote/helpers/formatVoteDataToCommit.ts
@@ -34,14 +34,17 @@ export async function formatVoteDataToCommit(
   const backupCommits = localStorage.getItem("backupCommits");
   if (backupCommits) {
     newCommits = { ...JSON.parse(backupCommits) };
+    // To prevent null errors in nested object, need to create these objects on the fly
+    // Based on if the user has voted before or not in a given round or using a given account
     if (!newCommits[address]) {
       newCommits[address] = {
         [roundId]: {},
       };
     }
+    if (newCommits[address] && !newCommits[address][roundId]) {
+      newCommits[address][roundId] = {};
+    }
   }
-
-  console.log("newCOmmits", newCommits);
 
   await Promise.all(
     activeRequests.map(async (el) => {

--- a/src/features/vote/helpers/formatVoteDataToCommit.ts
+++ b/src/features/vote/helpers/formatVoteDataToCommit.ts
@@ -14,7 +14,7 @@ import { FormData } from "../CommitPhase";
 
 // For the hashing being done here, we must adhere to the format expected later in the process by revealVote.
 // IE: identifier needs to be a hexstring, "yes" and "no" need to be 1 x 10**18 and 0 respectively, etc.
-interface BackupCommit {
+export interface BackupCommit {
   [address: string]: {
     [roundId: string]: {
       [indentifier: string]: string;
@@ -34,7 +34,14 @@ export async function formatVoteDataToCommit(
   const backupCommits = localStorage.getItem("backupCommits");
   if (backupCommits) {
     newCommits = { ...JSON.parse(backupCommits) };
+    if (!newCommits[address]) {
+      newCommits[address] = {
+        [roundId]: {},
+      };
+    }
   }
+
+  console.log("newCOmmits", newCommits);
 
   await Promise.all(
     activeRequests.map(async (el) => {

--- a/src/features/vote/helpers/formatVoteDataToCommit.ts
+++ b/src/features/vote/helpers/formatVoteDataToCommit.ts
@@ -11,6 +11,7 @@ import toWei from "common/utils/web3/convertToWeiSafely";
 import { getPrecisionForIdentifier, parseFixed } from "@uma/common";
 
 import { FormData } from "../CommitPhase";
+import setWith from "lodash.setwith";
 
 export interface BackupCommit {
   [address: string]: {
@@ -34,16 +35,18 @@ export async function formatVoteDataToCommit(
   const backupCommits = localStorage.getItem("backupCommits");
   if (backupCommits) {
     newCommits = { ...JSON.parse(backupCommits) };
-    // To prevent null errors in nested object, need to create these objects on the fly
-    // Based on if the user has voted before or not in a given round or using a given account
-    if (!newCommits[address]) {
-      newCommits[address] = {
-        [roundId]: {},
-      };
-    }
-    if (newCommits[address] && !newCommits[address][roundId]) {
-      newCommits[address][roundId] = {};
-    }
+    // // To prevent null errors in nested object, need to create these objects on the fly
+    // // Based on if the user has voted before or not in a given round or using a given account
+    // const key = `${address}.${roundId}.`
+    // set(newCommits, [])
+    // if (!newCommits[address]) {
+    //   newCommits[address] = {
+    //     [roundId]: {},
+    //   };
+    // }
+    // if (newCommits[address] && !newCommits[address][roundId]) {
+    //   newCommits[address][roundId] = {};
+    // }
   }
 
   await Promise.all(
@@ -86,7 +89,12 @@ export async function formatVoteDataToCommit(
         }
 
         const salt = getRandomSignedInt().toString();
-        newCommits[address][roundId][uniqueIdentifier] = salt;
+        setWith(
+          newCommits,
+          `${address}.[${roundId}].${uniqueIdentifier}`,
+          salt,
+          Object
+        );
 
         const r: Request = {
           price,

--- a/src/features/vote/helpers/formatVoteDataToCommit.ts
+++ b/src/features/vote/helpers/formatVoteDataToCommit.ts
@@ -74,6 +74,8 @@ export async function formatVoteDataToCommit(
           );
 
           price = parseFixed(price, identifierPrecision).toString();
+          // Asked to be put here temporarily by @nickpai
+          console.log("price to commit:", price);
         }
 
         const salt = getRandomSignedInt().toString();

--- a/src/features/vote/helpers/formatVoteDataToCommit.ts
+++ b/src/features/vote/helpers/formatVoteDataToCommit.ts
@@ -16,7 +16,7 @@ import setWith from "lodash.setwith";
 export interface BackupCommit {
   [address: string]: {
     [roundId: string]: {
-      [indentifier: string]: string;
+      [identifier: string]: string;
     };
   };
 }

--- a/src/features/vote/helpers/formatVoteDataToCommit.ts
+++ b/src/features/vote/helpers/formatVoteDataToCommit.ts
@@ -35,18 +35,6 @@ export async function formatVoteDataToCommit(
   const backupCommits = localStorage.getItem("backupCommits");
   if (backupCommits) {
     newCommits = { ...JSON.parse(backupCommits) };
-    // // To prevent null errors in nested object, need to create these objects on the fly
-    // // Based on if the user has voted before or not in a given round or using a given account
-    // const key = `${address}.${roundId}.`
-    // set(newCommits, [])
-    // if (!newCommits[address]) {
-    //   newCommits[address] = {
-    //     [roundId]: {},
-    //   };
-    // }
-    // if (newCommits[address] && !newCommits[address][roundId]) {
-    //   newCommits[address][roundId] = {};
-    // }
   }
 
   await Promise.all(

--- a/src/features/vote/helpers/formatVoteDataToCommit.ts
+++ b/src/features/vote/helpers/formatVoteDataToCommit.ts
@@ -12,8 +12,6 @@ import { getPrecisionForIdentifier, parseFixed } from "@uma/common";
 
 import { FormData } from "../CommitPhase";
 
-// For the hashing being done here, we must adhere to the format expected later in the process by revealVote.
-// IE: identifier needs to be a hexstring, "yes" and "no" need to be 1 x 10**18 and 0 respectively, etc.
 export interface BackupCommit {
   [address: string]: {
     [roundId: string]: {
@@ -22,6 +20,8 @@ export interface BackupCommit {
   };
 }
 
+// For the hashing being done here, we must adhere to the format expected later in the process by revealVote.
+// IE: identifier needs to be a hexstring, "yes" and "no" need to be 1 x 10**18 and 0 respectively, etc.
 export async function formatVoteDataToCommit(
   data: FormData,
   activeRequests: PendingRequest[],
@@ -113,7 +113,5 @@ export async function formatVoteDataToCommit(
     })
   );
 
-  localStorage.setItem("backupCommits", JSON.stringify(newCommits));
-
-  return postValues;
+  return { postValues, newCommits };
 }

--- a/src/features/vote/styled/ActiveRequests.styled.tsx
+++ b/src/features/vote/styled/ActiveRequests.styled.tsx
@@ -101,12 +101,12 @@ export const Table = styled.table<TableProps>`
     td {
       border-color: #fff;
       border-style: solid;
-      /* border-width: 0 15px; */
       vertical-align: middle;
       border-bottom: 1px solid #e5e4e4;
+      border-right: 12px solid transparent;
+      border-left: 12px solid transparent;
       div {
         display: flex;
-        /* align-items: center; */
       }
       .description {
         max-width: 60ch;
@@ -114,9 +114,6 @@ export const Table = styled.table<TableProps>`
     }
 
     .last-cell {
-      div {
-        /* padding-left: 25%; */
-      }
     }
     td:last-child {
       text-align: center;

--- a/src/features/vote/styled/ActiveRequests.styled.tsx
+++ b/src/features/vote/styled/ActiveRequests.styled.tsx
@@ -103,8 +103,9 @@ export const Table = styled.table<TableProps>`
       border-style: solid;
       vertical-align: middle;
       border-bottom: 1px solid #e5e4e4;
-      border-right: 12px solid transparent;
-      border-left: 12px solid transparent;
+      &:first-of-type {
+        border-right: 12px solid transparent;
+      }
       div {
         display: flex;
       }

--- a/src/features/vote/styled/DetailModals.styled.tsx
+++ b/src/features/vote/styled/DetailModals.styled.tsx
@@ -130,4 +130,17 @@ export const RevealPercentage = styled.div`
 
 export const LastStateValue = styled(StateValue)`
   padding-bottom: 3rem;
+  display: flex;
+  max-width: 100%;
+  font-size: 0.75rem;
+  div {
+    justify-content: space-between;
+    color: grey;
+    &:nth-child(2) {
+      padding-left: 1rem;
+      flex-grow: 1;
+      max-width: 300px;
+      word-break: break-word;
+    }
+  }
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4862,7 +4862,21 @@
     "@types/abstract-leveldown" "*"
     "@types/node" "*"
 
-"@types/lodash@^4.14.104":
+"@types/lodash.has@^4.5.6":
+  version "4.5.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.has/-/lodash.has-4.5.6.tgz#d94d3f0b45ced2ae76d632080daf70e9b76e29eb"
+  integrity sha512-SpUCvze0uHilQX/mt4K/cak5OQny1pVfz3pJx6H70dE3Tvw9s7EtlMK+vY6UBS+PQgETDfv6vhwoa3FPS2wrhg==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash.setwith@^4.3.6":
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.setwith/-/lodash.setwith-4.3.6.tgz#8ed248283f55087bf8da450c23f3c87d03c90e76"
+  integrity sha512-ODbGMJFCPHbKyeYxhnUoSh9Om9aGO/pW1B0EZHEH3ZIU4vfdfgchlLm5e+UujtHME3OMeVyL9nEgm+tEkiHMjQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*", "@types/lodash@^4.14.104":
   version "4.14.170"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.170.tgz#0d67711d4bf7f4ca5147e9091b847479b87925d6"
   integrity sha512-bpcvu/MKHHeYX+qeEN8GE7DIravODWdACVA1ctevD8CN24RhPZIKMn9ntfAsrvLfSX3cR5RrBKAbYm9bGs0A+Q==
@@ -16774,6 +16788,11 @@ lodash.set@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
   integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
+
+lodash.setwith@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/lodash.setwith/-/lodash.setwith-4.3.2.tgz#1bcc057e62d90f5a6b9b9470ae2ab9d89edd8e6f"
+  integrity sha1-G8wFfmLZD1prm5Rwriq52J7djm8=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"


### PR DESCRIPTION
Backup seed used for a particular round.

Apparently only the salt is required.
https://app.clubhouse.io/uma-project/story/1279/add-ability-to-view-voters-backup-commit-seed
<img width="571" alt="Screen Shot 2021-06-23 at 3 00 07 PM" src="https://user-images.githubusercontent.com/12792146/123174714-6b17a900-d435-11eb-947d-a355cde93d01.png">

Added some padding to cells:

https://app.clubhouse.io/uma-project/story/1497/fix-spacing-between-rows
