### PR TITLE
Feat: Better flow for committing if unsigned.

### DIFF
--- a/src/features/vote/CommitPhase.tsx
+++ b/src/features/vote/CommitPhase.tsx
@@ -24,7 +24,11 @@ import { OnboardContext } from "common/context/OnboardContext";
 import { formatVoteDataToCommit } from "./helpers/formatVoteDataToCommit";
 import { EncryptedVote } from "web3/get/queryEncryptedVotesEvents";
 
-import { FormWrapper, CommitInputLabel } from "./styled/CommitPhase.styled";
+import {
+  FormWrapper,
+  CommitInputLabel,
+  NoPublicKeyErrorWrapper,
+} from "./styled/CommitPhase.styled";
 import { VoteRevealed } from "web3/get/queryVotesRevealedEvents";
 import { ModalState } from "./ActiveRequests";
 
@@ -253,6 +257,11 @@ const CommitPhase: FC<Props> = ({
     }
   }, [watchAllFields, setButtonVariant]);
 
+  const [noPublicKeyError, setNoPublicKeyError] = useState(false);
+  useEffect(() => {
+    if (publicKey && noPublicKeyError) setNoPublicKeyError(false);
+  }, [publicKey, noPublicKeyError]);
+
   return (
     <FormWrapper
       className="CommitPhase"
@@ -392,11 +401,18 @@ const CommitPhase: FC<Props> = ({
             type="button"
             variant={buttonVariant}
             onClick={() => {
-              if (showModalSummary().length) open();
+              if (!publicKey) return setNoPublicKeyError(true);
+              if (showModalSummary().length) return open();
             }}
           >
             Commit Vote(s)
           </Button>
+          {noPublicKeyError && (
+            <NoPublicKeyErrorWrapper>
+              Message was not signed. Reconnect to your wallet and sign the
+              message to continue.
+            </NoPublicKeyErrorWrapper>
+          )}
         </div>
       </div>
       <SubmitCommitsModal

--- a/src/features/vote/styled/CommitPhase.styled.tsx
+++ b/src/features/vote/styled/CommitPhase.styled.tsx
@@ -47,6 +47,7 @@ export const FormWrapper = styled.form<StyledFormProps>`
       display: flex;
       justify-content: flex-end;
       .end-row-item {
+        text-align: right;
       }
     }
   }
@@ -62,4 +63,15 @@ export const CommitInputLabel = styled.label`
   display: block;
   color: #000;
   font-family: "Halyard Display";
+`;
+
+export const NoPublicKeyErrorWrapper = styled.div`
+  color: #ff4a4a;
+  background-color: #fff4f6;
+  border: 1px solid #ffd6d9;
+  border-radius: 8px;
+  max-width: 400px;
+  text-align: left;
+  padding: 0.5rem 1rem;
+  margin-top: 0.5rem;
 `;


### PR DESCRIPTION
Modal does not open if key is unsigned. Error messages below pops up instead.

![vote-error01](https://user-images.githubusercontent.com/12792146/123465400-efd40580-d5a2-11eb-9287-e4615cb634f7.png)

https://app.clubhouse.io/uma-project/story/1384/dapp-allows-user-to-go-through-the-voting-process-without-signing-make-the-dapp-present-an-error-message-when-the-user-clicks

Signed-off-by: Tulun <jaykiraly@gmail.com>