### PR TITLE
fix: allow designated voting contract to be set more than once

### DIFF
--- a/src/hooks/useVotingAddress.ts
+++ b/src/hooks/useVotingAddress.ts
@@ -31,8 +31,8 @@ export default function useVotingAddress(
         }).catch((err:Error)=>{
           console.error('Error getting designated voting address:',err)
         });
-    }else{
-      setVotingAddress(address);
+    } else {
+      setVotingAddress(null);
     }
   }, [address, signer, network]);
 

--- a/src/hooks/useVotingAddress.ts
+++ b/src/hooks/useVotingAddress.ts
@@ -28,9 +28,12 @@ export default function useVotingAddress(
             setVotingAddress(res);
             setHotAddress(address);
           }
+        }).catch((err:Error)=>{
+          console.error('Error getting designated voting address:',err)
         });
+    }else{
+      setVotingAddress(address);
     }
-    setVotingAddress(address);
   }, [address, signer, network]);
 
   return {

--- a/src/hooks/useVotingContract.ts
+++ b/src/hooks/useVotingContract.ts
@@ -29,13 +29,14 @@ export default function useVotingContract(
           network.chainId.toString()
         );
         setVotingContract(contract);
-        if (hotAddress && voterAddress) {
-          const dvc = createDesignatedVotingContractInstance(
-            signer,
-            voterAddress
-          );
-          setDesignatedVotingContract(dvc);
-        }
+      }
+      // we want this to be able to change when user switches accounts. previously this was only being able to be set once.
+      if (signer && hotAddress && voterAddress) {
+        const dvc = createDesignatedVotingContractInstance(
+          signer,
+          voterAddress
+        );
+        setDesignatedVotingContract(dvc);
       }
     }
   }, [isConnected, signer, votingContract, network, hotAddress, voterAddress]);

--- a/src/web3/get/queryEncryptedVotesEvents.ts
+++ b/src/web3/get/queryEncryptedVotesEvents.ts
@@ -40,7 +40,6 @@ export const queryEncryptedVotes = async (
   // EncryptedVote: (address,uint256,bytes32,uint256,bytes,bytes)
   const filter = contract.filters.EncryptedVote(
     address,
-    // null,
     roundId ? Number(roundId) : null,
     identifier,
     time,


### PR DESCRIPTION
### Motivation:

https://app.clubhouse.io/uma-project/story/2258/a-commit-transaction-was-successful-but-ui-shows-uncommitted

### Bug
What ended up happenign was on commit, it would not commit to the 2key contract. Deep in the code the cause was that the designated contract instance was undefined, but everything else looked correct. So there was an issue with instantiating the 2key contract instance. 

### Summary:
2 main changes here. In useVotingAddress there was a useEffect which looks like it could possibly override your voting address.
More likely the bug was in useVotingContract, where the designated voting contract could not be set more than once. Meaning if for some reason your voting address was undefined, it could never be set again once it became defined (at least thats my best guess). 

### Testing
Tested this in production with my account, as it would never send to the 2key voting contract, and now it does. 