### PR TITLE
fix: use latest log when multiple encrypted events collide in same block

### DIFF
--- a/src/web3/get/queryEncryptedVotesEvents.ts
+++ b/src/web3/get/queryEncryptedVotesEvents.ts
@@ -59,9 +59,9 @@ export const queryEncryptedVotes = async (
           args.roundId.toString(),
           args.time.toString(),
         ].join("!");
-        // if multiple commit events, always take the newest one
+        // if multiple commit events, always take the newest one, and latest log
         if (result[key]) {
-          if (result[key].blockNumber < event.blockNumber) result[key] = event;
+          if (result[key].blockNumber <= event.blockNumber) result[key] = event;
         } else {
           result[key] = event;
         }


### PR DESCRIPTION
hotfix https://app.shortcut.com/uma-project/story/2352/fix-voter-dapp-when-duplicate-commits-are-sent

This change is under the assumption that logs are returned in executed order, from earliest to latest. This change takes the latest log when conflict is found within the same block for encrypted events.
Signed-off-by: David A <david@umaproject.org>