### PR TITLE
feat: Sign only once a round.

### DIFF
--- a/src/common/context/OnboardContext.tsx
+++ b/src/common/context/OnboardContext.tsx
@@ -159,7 +159,7 @@ const connect = async (
     const onboardInstance = createOnboardInstance(network, subscriptions);
 
     await onboardInstance.walletSelect();
-    await onboardInstance.walletCheck();
+    // await onboardInstance.walletCheck();
 
     dispatch({ type: actions.SET_ONBOARD, payload: onboardInstance });
     dispatch({ type: actions.SET_CONNECTION_STATUS, payload: true });

--- a/src/hooks/useSigningKeys.ts
+++ b/src/hooks/useSigningKeys.ts
@@ -19,7 +19,11 @@ export default function useSigningKeys(
   address: string | null,
   roundId: string
 ) {
-  const [signingKeys, setSigningKeys] = useState<SigningKeys>({});
+  const storageKeys = localStorage.getItem("signingKeys");
+
+  const [signingKeys, setSigningKeys] = useState<SigningKeys>(
+    storageKeys ? (JSON.parse(storageKeys) as SigningKeys) : {}
+  );
 
   const { addError } = useContext(ErrorContext);
 

--- a/src/hooks/useSigningKeys.ts
+++ b/src/hooks/useSigningKeys.ts
@@ -2,6 +2,10 @@ import { ethers } from "ethers";
 import { useState, useEffect, useContext } from "react";
 import { ErrorContext } from "common/context/ErrorContext";
 
+import { recoverPublicKey } from "features/vote/helpers/recoverPublicKey";
+import { derivePrivateKey } from "features/vote/helpers/derivePrivateKey";
+import usePrevious from "common/hooks/usePrevious";
+
 export interface SigningKeys {
   [key: string]: {
     publicKey: string;
@@ -10,13 +14,9 @@ export interface SigningKeys {
   };
 }
 
-import { recoverPublicKey } from "features/vote/helpers/recoverPublicKey";
-import { derivePrivateKey } from "features/vote/helpers/derivePrivateKey";
-import usePrevious from "common/hooks/usePrevious";
-
 export default function useSigningKeys(
   signer: ethers.Signer | null,
-  address: string,
+  address: string | null,
   roundId: string
 ) {
   const [signingKeys, setSigningKeys] = useState<SigningKeys>({});
@@ -52,7 +52,10 @@ export default function useSigningKeys(
             key.roundMessage = message;
 
             setSigningKeys((prevKeys) => {
-              return { ...prevKeys, [address]: key };
+              const updateKeys = { ...prevKeys, [address]: key };
+              localStorage.setItem("signingKeys", JSON.stringify(updateKeys));
+
+              return updateKeys;
             });
           })
           .catch((err) => {
@@ -71,5 +74,8 @@ export default function useSigningKeys(
     roundId,
   ]);
 
-  return signingKeys;
+  return {
+    signingKeys,
+    setSigningKeys,
+  };
 }

--- a/src/hooks/useSigningKeys.ts
+++ b/src/hooks/useSigningKeys.ts
@@ -6,8 +6,10 @@ import { recoverPublicKey } from "features/vote/helpers/recoverPublicKey";
 import { derivePrivateKey } from "features/vote/helpers/derivePrivateKey";
 import usePrevious from "common/hooks/usePrevious";
 
+// User has to sign once per round.
+// public and private signing keys is indexed by address, and we ask them to resign if the roundMessage changes.
 export interface SigningKeys {
-  [key: string]: {
+  [address: string]: {
     publicKey: string;
     privateKey: string;
     roundMessage: string;

--- a/src/hooks/useSigningKeys.ts
+++ b/src/hooks/useSigningKeys.ts
@@ -1,0 +1,75 @@
+import { ethers } from "ethers";
+import { useState, useEffect, useContext } from "react";
+import { ErrorContext } from "common/context/ErrorContext";
+
+export interface SigningKeys {
+  [key: string]: {
+    publicKey: string;
+    privateKey: string;
+    roundMessage: string;
+  };
+}
+
+import { recoverPublicKey } from "features/vote/helpers/recoverPublicKey";
+import { derivePrivateKey } from "features/vote/helpers/derivePrivateKey";
+import usePrevious from "common/hooks/usePrevious";
+
+export default function useSigningKeys(
+  signer: ethers.Signer | null,
+  address: string,
+  roundId: string
+) {
+  const [signingKeys, setSigningKeys] = useState<SigningKeys>({});
+
+  const { addError } = useContext(ErrorContext);
+
+  const previousSigner = usePrevious(signer);
+  const previousAddress = usePrevious(address);
+
+  useEffect(() => {
+    if (
+      signer &&
+      address &&
+      roundId &&
+      (previousAddress === null || previousSigner === null)
+    ) {
+      const message = `UMA Protocol one time key for round: ${roundId}`;
+      const keyExists = signingKeys[address];
+      if (!keyExists || keyExists.roundMessage !== message) {
+        signer
+          .signMessage(message)
+          .then((msg) => {
+            const key = {} as {
+              publicKey: string;
+              privateKey: string;
+              roundMessage: string;
+            };
+
+            const privateKey = derivePrivateKey(msg);
+            const publicKey = recoverPublicKey(privateKey);
+            key.privateKey = privateKey;
+            key.publicKey = publicKey;
+            key.roundMessage = message;
+
+            setSigningKeys((prevKeys) => {
+              return { ...prevKeys, [address]: key };
+            });
+          })
+          .catch((err) => {
+            const error = new Error("Sign failed.");
+            addError(error);
+          });
+      }
+    }
+  }, [
+    signer,
+    address,
+    signingKeys,
+    addError,
+    previousAddress,
+    previousSigner,
+    roundId,
+  ]);
+
+  return signingKeys;
+}


### PR DESCRIPTION
Motivation:

User should only need to sign once per round to reduce friction per account.

Details:

Created a useSigningKeys hook to hold the relevant state, and then have it instantiate a base state object based on whether or not the user has a signingKeys object in localStorage.