### PR TITLE
feat(manualreveal): add manual reveal scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ yarn-debug.log*
 yarn-error.log*
 
 .vercel
+backupCommits

--- a/manualreveal/README.md
+++ b/manualreveal/README.md
@@ -1,0 +1,55 @@
+# Manual Reveal Script
+
+This is a tool for [UMA Voting Dapp](vote.umaproject.org), when you are unable to reveal through the website for some reason.
+This script allows you to input backed up values and provides you with an output string to allow a manual reveal through etherscan for a non 2-key voter.
+
+## Quick Start
+
+In order to run, you must clone the voter dapp:
+
+`git clone https://github.com/UMAprotocol/voter-dapp.git`
+
+Then you must install dependencies inside the `voter-dapp` folder.
+
+`cd voter-dapp && yarn`
+
+Finally run the manual reveal script:
+
+`yarn reveal`
+
+This will prompt you to select a script to run.
+
+## Revealing with your private key
+
+The easiest way to reveal is using the login signature from the [Voter Dapp](vote.umaproject.org).
+
+Once you run the script, select 1 to reveal with private key.
+
+You can your private key signature first signing into the app, then visiting your browsers dev tools.
+The application tab -> local storage -> `https://vote.umaproject.org`. Once here you should see a field for `signingKeys`.
+Click the signing keys and copy the `privateKey` hex string. You will need to paste this into the script when prompted.
+
+Follow the prompts to produce the reveal string. Save the output for a manual reveal in etherscan.
+
+## Revealing with backup commits
+
+This requires you add a file called `backupCommits` with an object copied from your local storage in the Voter Dapp.
+You will also need to know the values you committed for each vote. When running the script, select 2 to try this method.
+
+In order to find the backup commits object first open your browsers dev tools.
+In the application tab -> local storage -> `https://vote.umaproject.org`. Once here you should see a field for `backupCommits`.
+Click the backupCommits field, and then right click and copy the entire object. Paste this into a file inside the voter-dapp folder
+called `backupCommits`.
+
+Follow the prompts to produce the reveal string. Save the output for a manual reveal in etherscan.
+
+## Manually Revealing on Etherscan
+
+To reveal on ethereum mainnet, visit this link to [UMAs Voting Contract](https://etherscan.io/address/0x8b1631ab830d11531ae83725fda4d86012eccd77#writeContract).
+Make sure you are in the `Contract-> Write Contract` tab. Connect your Metamask wallet where it says `Connect to Web3`.
+Once connected, find the `batchReveal` function. There may be 2 of them, paste the output of the scripts into the second one.
+Press the `Write` button and send the transaction through Metamask.
+
+## Verify Reveal
+
+After a few minutes, the Voter Dapp should update with revealed statuses for your votes if everything worked correctly.

--- a/manualreveal/index.ts
+++ b/manualreveal/index.ts
@@ -1,0 +1,52 @@
+import dotenv from "dotenv";
+import prompt from "prompt";
+import revealWithSalt from "./revealWithSalt";
+import revealWithPrivateKey from "./revealWithPrivateKey";
+dotenv.config();
+
+// environment variables are completely optional, by default you will be prompted to enter this information or it will be deduced
+const {
+  network = "1",
+  roundId,
+  publicAddress,
+  privateKey,
+  backupCommitsFile,
+} = process.env;
+
+async function run() {
+  prompt.start();
+  const promptConfig = [
+    {
+      name: "runScript",
+      description: `
+  Choose a script:
+  0. Exit
+  1. Reveal With Private Key
+  2. Reveal With Salt Backup Commit File`,
+      required: true,
+      default: 1,
+    },
+  ];
+  const { runScript } = await prompt.get(promptConfig);
+  switch (Number(runScript.toString())) {
+    case 1:
+      return revealWithPrivateKey({
+        network,
+        publicAddress,
+        roundId,
+        privateKey,
+      });
+    case 2:
+      return revealWithSalt({
+        network,
+        publicAddress,
+        roundId,
+        backupCommitsFile,
+      });
+    default:
+  }
+}
+
+run()
+  .then((x) => console.log(JSON.stringify(x)))
+  .catch((err) => console.error(err.message));

--- a/manualreveal/revealWithPrivateKey.ts
+++ b/manualreveal/revealWithPrivateKey.ts
@@ -1,0 +1,38 @@
+import { ethers } from "ethers";
+import * as reveal from "../src/common/helpers/reveal";
+import prompt from "prompt";
+
+type Config = {
+  network: string;
+  roundId?: string;
+  publicAddress?: string;
+  privateKey?: string;
+};
+export default async (config: Config) => {
+  prompt.start();
+  const promptConfig = [
+    {
+      name: "publicAddress",
+      description: "Enter your voting public address",
+      required: true,
+      default: config.publicAddress,
+    },
+    {
+      name: "privateKey",
+      description: "Enter your signed keys private key",
+      required: true,
+      default: config.privateKey,
+    },
+  ];
+  const { publicAddress, privateKey } = await prompt.get(promptConfig);
+  const provider = ethers.getDefaultProvider(
+    ethers.providers.getNetwork(Number(config.network))
+  );
+  return reveal.encodeWithPrivateKey(
+    provider as unknown as ethers.Signer,
+    config.network,
+    publicAddress.toString(),
+    privateKey.toString(),
+    config.roundId
+  );
+};

--- a/manualreveal/revealWithSalt.ts
+++ b/manualreveal/revealWithSalt.ts
@@ -1,0 +1,60 @@
+import { ethers } from "ethers";
+import * as reveal from "../src/common/helpers/reveal";
+import prompt from "prompt";
+import fs from "fs";
+
+type Config = {
+  network: string;
+  roundId?: string;
+  publicAddress?: string;
+  backupCommitsFile?: string;
+};
+export default async (config: Config) => {
+  prompt.start();
+  const promptConfig = [
+    {
+      name: "publicAddress",
+      description: "Enter your voting public address",
+      required: true,
+      default: config.publicAddress,
+    },
+    {
+      name: "backupCommitsFile",
+      description:
+        "Enter a path to file containing the full salt object copied from local storage",
+      default: config.backupCommitsFile || "backupCommits",
+      required: true,
+    },
+  ];
+  const { publicAddress, backupCommitsFile } = await prompt.get(promptConfig);
+  const backupCommits = JSON.parse(
+    fs.readFileSync(backupCommitsFile.toString(), "utf8")
+  );
+  const provider = ethers.getDefaultProvider(
+    ethers.providers.getNetwork(Number(config.network))
+  );
+  const resultsNeedingPrice = await reveal.encodeWithSaltBackup(
+    provider as unknown as ethers.Signer,
+    config.network,
+    publicAddress.toString(),
+    backupCommits,
+    config.roundId
+  );
+  const prices = await prompt.get(
+    resultsNeedingPrice.map((result, i: number) => {
+      return {
+        name: i.toString(),
+        required: true,
+        description:`Enter committed price, 0 for No, or 1 for Yes for ${reveal.makeKey(result)}`,
+      };
+    })
+  );
+  return reveal.etherscanBatchReveal(
+    Object.entries(prices).map(([index, price]) => {
+      return {
+        ...resultsNeedingPrice[Number(index.toString())],
+        price: ethers.utils.parseEther(price.toString()).toString(),
+      };
+    })
+  );
+};

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "test:coverage": "yarn test --coverage --watchAll=false",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "reveal": "ts-node ./manualreveal"
   },
   "eslintConfig": {
     "extends": [
@@ -83,12 +84,17 @@
   },
   "devDependencies": {
     "@types/crypto-js": "^4.0.1",
+    "@types/dotenv": "^8.2.0",
     "@types/lodash.has": "^4.5.6",
     "@types/lodash.setwith": "^4.3.6",
     "@types/luxon": "^1.26.2",
+    "@types/prompt": "^1.1.1",
     "@types/react-router-dom": "^5.1.7",
+    "dotenv": "^10.0.0",
     "eth-crypto": "^1.9.0",
     "nock": "^13.0.11",
+    "prompt": "^1.2.0",
+    "ts-node": "^10.3.0",
     "web3": "^1.3.5"
   }
 }

--- a/src/common/helpers/reveal.ts
+++ b/src/common/helpers/reveal.ts
@@ -1,0 +1,92 @@
+import { ethers,BigNumber } from "ethers";
+import assert from 'assert'
+// note these imports use relative directories because this file is used in the manual reveal script with ts-node
+import createVotingContractInstance from "../web3/createVotingContractInstance";
+import createDesignatedVotingContractInstance from "../web3/createDesignatedVotingContractInstance";
+import { VOTER_CONTRACT_BLOCK } from "../config";
+import { decryptMessage } from "../tempUmaFunctions";
+import { PostRevealData } from "../web3/post/revealVotes";
+import { queryCurrentRoundId } from "../web3/get/queryCurrentRoundId";
+
+export async function queryEncryptedVotes(contract:ethers.Contract,address:string,roundId:string){
+  const filter = contract.filters.EncryptedVote(
+    address,
+    Number(roundId),
+    null,
+    null,
+    null,
+    null
+  );
+  return contract.queryFilter(filter,VOTER_CONTRACT_BLOCK);
+}
+
+type EtherscanReveal = [string, string, string, string, string]
+type EtherscanBatchReveal = EtherscanReveal[]
+type BackupCommitsForRound = Record<string,string>
+type BackupCommitsForAccount = Record<string,BackupCommitsForRound>
+type BackupCommits = Record<string,BackupCommitsForAccount>
+
+export async function encodeWithPrivateKey(signer:ethers.Signer,networkId:string, address:string, privateKey:string,roundId?:string):Promise<EtherscanBatchReveal>{
+  const votingContract = createVotingContractInstance(signer,networkId)
+  roundId = roundId || await queryCurrentRoundId(votingContract)
+  assert(roundId,'missing roundId')
+  const events = await queryEncryptedVotes(votingContract,address,roundId)
+  assert(events.length,'No commited votes found for round id: ' + roundId)
+  const revealData = await Promise.all(
+    events.map(event=>decodeEncryptedVoteWithPK(event.args as ethers.utils.Result,privateKey))
+  )
+  return etherscanBatchReveal(revealData)
+}
+
+
+export async function encodeWithSaltBackup(signer:ethers.Signer,networkId:string, address:string, backupCommits:BackupCommits, roundId?:string):Promise<PostRevealData[]>{
+  const votingContract = createVotingContractInstance(signer,networkId)
+  roundId = roundId || await queryCurrentRoundId(votingContract)
+  assert(roundId,'no round id found')
+  const myBackupCommits = findValueByKey<string,BackupCommitsForAccount>(backupCommits,address) || findValueByKey<string,BackupCommitsForAccount>(backupCommits,address.toLowerCase())
+  assert(myBackupCommits,'missing backup commits for address: ' + address)
+  const roundBackupCommits = findValueByKey<string,BackupCommitsForRound>(myBackupCommits,roundId.toString())
+  assert(roundBackupCommits,'missing round commits for current round: ' + roundId)
+  const events = await queryEncryptedVotes(votingContract,address,roundId)
+  assert(events.length,'No commited votes found for round id: ' + roundId)
+  return Promise.all(
+    events.map(event=>decodeEncryptedVoteWithBackup(event.args as ethers.utils.Result,roundBackupCommits))
+  )
+}
+
+export function makeKey(args:Pick<PostRevealData,'identifier'|'time'|'ancillaryData'>):string{
+  return [ethers.utils.toUtf8String(args.identifier).trim(),args.time.toString(), args.ancillaryData.toString()].join('~')
+}
+// dont understand why, but regular lookups, or lodash.get not working in objects pasted from localstorage
+function findValueByKey<K extends string | number,V>(obj:Record<K,V>,find:K):V | undefined {
+  const found = Object.entries(obj).find(([k,v])=>k===find)
+  if(found) return found[1] as unknown as V
+}
+export async function decodeEncryptedVoteWithBackup(args:ethers.utils.Result,roundBackupCommits:BackupCommitsForRound):Promise<PostRevealData>{
+  const key = makeKey(args as unknown as Pick<PostRevealData,'identifier'|'time'|'ancillaryData'>)
+  const salt = findValueByKey<string,string>(roundBackupCommits,key)
+  assert(salt,'Could not find salt for vote: ' + key)
+  return {
+    price:'',
+    salt:salt.toString(),
+    identifier:args.identifier,
+    time:args.time.toString(),
+    ancillaryData:args.ancillaryData,
+  }
+}
+export async function decodeEncryptedVoteWithPK(args:ethers.utils.Result,privateKey:string):Promise<PostRevealData>{
+  const {price,salt} = JSON.parse(await decryptMessage(privateKey, args.encryptedVote));
+  return {
+    price:price.toString(),
+    salt:salt.toString(),
+    identifier:args.identifier,
+    time:args.time.toString(),
+    ancillaryData:args.ancillaryData,
+  }
+}
+
+export function etherscanBatchReveal(data:PostRevealData[]):EtherscanBatchReveal{
+  return data.map(datum=>{
+    return [datum.identifier,datum.time.toString(),datum.price,datum.ancillaryData,datum.salt]
+  })
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,11 @@
     "jsx": "react-jsx",
     "jsxImportSource": "@emotion/react" // for the css prop
   },
+  "ts-node":{
+    "compilerOptions": {
+      "module": "commonjs"
+    }
+  },
   "include": ["src"],
   "files": ["src/twin.d.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1367,6 +1367,18 @@
     buffer "^5.4.3"
     seedrandom "^3.0.5"
 
+"@cspotcode/source-map-consumer@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
+  integrity sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
+
+"@cspotcode/source-map-support@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz#4789840aa859e46d2f3173727ab707c66bf344f5"
+  integrity sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==
+  dependencies:
+    "@cspotcode/source-map-consumer" "0.8.0"
+
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
@@ -4620,6 +4632,26 @@
     xhr "^2.2.0"
     xtend "^4.0.1"
 
+"@tsconfig/node10@^1.0.7":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
+  integrity sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
+  integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
+  integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
+  integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
+
 "@types/abstract-leveldown@*":
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/@types/abstract-leveldown/-/abstract-leveldown-5.0.2.tgz#ee81917fe38f770e29eec8139b6f16ee4a8b0a5f"
@@ -4763,6 +4795,13 @@
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-4.0.2.tgz#4524325a175bf819fec6e42560c389ce1fb92c97"
   integrity sha512-sCVniU+h3GcGqxOmng11BRvf9TfN9yIs8KKjB8C8d75W69cpTfZG80gau9yTx5SxF3gvHGbJhdESzzvnjtf3Og==
+
+"@types/dotenv@^8.2.0":
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/@types/dotenv/-/dotenv-8.2.0.tgz#5cd64710c3c98e82d9d15844375a33bf1b45d053"
+  integrity sha512-ylSC9GhfRH7m1EUXBXofhgx4lUWmFeQDINW5oLuS+gxWdfUeW4zJdeVTYVkexEW+e2VUvlZR2kGnGGipAWR7kw==
+  dependencies:
+    dotenv "*"
 
 "@types/ed2curve@^0.2.2":
   version "0.2.2"
@@ -5049,6 +5088,14 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.3.2.tgz#fc8c2825e4ed2142473b4a81064e6e081463d1b3"
   integrity sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==
 
+"@types/prompt@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/prompt/-/prompt-1.1.1.tgz#b78e9964db26910e41aea68fbfb204adcb548e16"
+  integrity sha512-Ht3nSZy87jqKM5Y92GWKD6RQTqQIi6tAKhrWgEvFPh+P13L5olqBYs+P1HySBYRHyIezEqrB3StK4X7lBFmIEQ==
+  dependencies:
+    "@types/node" "*"
+    "@types/revalidator" "*"
+
 "@types/prop-types@*":
   version "15.7.4"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
@@ -5146,6 +5193,11 @@
   integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
   dependencies:
     "@types/node" "*"
+
+"@types/revalidator@*":
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/@types/revalidator/-/revalidator-0.3.8.tgz#86e0b03b49736000ad42ce6b002725e74c6805ff"
+  integrity sha512-q6KSi3PklLGQ0CesZ/XuLwly4DXXlnJuucYOG9lrBqrP8rKiuPZThav2h2+pFjaheNpnT0qKK3i304QWIePeJw==
 
 "@types/scheduler@*":
   version "0.16.2"
@@ -6124,6 +6176,11 @@ acorn-walk@^7.0.0, acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@4.X, acorn@^4.0.3:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
@@ -6548,6 +6605,11 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
+
 arg@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.0.tgz#a20e2bb5710e82950a516b3f933fee5ed478be90"
@@ -6830,6 +6892,16 @@ async@^2.0.1, async@^2.1.2, async@^2.4.0, async@^2.5.0, async@^2.6.2:
   integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
   dependencies:
     lodash "^4.17.14"
+
+async@~0.9.0:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
+  integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
+
+async@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-1.0.0.tgz#f8fc04ca3a13784ade9e1641af98578cfbd647a9"
+  integrity sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -9200,6 +9272,11 @@ colorette@^1.2.1, colorette@^1.2.2:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
+colors@1.0.x:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
+  integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
+
 colors@^1.1.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
@@ -9614,6 +9691,11 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-fetch@3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.6.tgz#3a4040bc8941e653e0e9cf17f29ebcd177d3365c"
@@ -10004,6 +10086,11 @@ currently-unhandled@^0.4.1:
   integrity sha1-mI3zP+qxke95mmE2nddsF635V+o=
   dependencies:
     array-find-index "^1.0.1"
+
+cycle@1.0.x:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/cycle/-/cycle-1.0.3.tgz#21e80b2be8580f98b468f379430662b046c34ad2"
+  integrity sha1-IegLK+hYD5i0aPN5QwZisEbDStI=
 
 cyclist@^1.0.1:
   version "1.0.1"
@@ -10405,7 +10492,7 @@ diff@3.5.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
-diff@4.0.2:
+diff@4.0.2, diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
@@ -10622,6 +10709,11 @@ dotenv-expand@5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"
   integrity sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==
+
+dotenv@*, dotenv@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
+  integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
 
 dotenv@8.2.0:
   version "8.2.0"
@@ -12461,6 +12553,11 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
+
+eyes@0.1.x:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
+  integrity sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=
 
 fake-merkle-patricia-tree@^1.0.1:
   version "1.0.1"
@@ -15386,7 +15483,7 @@ isomorphic-ws@4.0.1, isomorphic-ws@^4.0.1:
   resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz#55fd4cd6c5e6491e76dc125938dd863f5cd4f2dc"
   integrity sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==
 
-isstream@~0.1.2:
+isstream@0.1.x, isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
@@ -17187,6 +17284,11 @@ make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   dependencies:
     semver "^6.0.0"
 
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -18063,6 +18165,11 @@ murmurhash3js-revisited@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz#6bd36e25de8f73394222adc6e41fa3fac08a5869"
   integrity sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g==
+
+mute-stream@~0.0.4:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
+  integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
 nan@2.14.0:
   version "2.14.0"
@@ -20665,6 +20772,17 @@ promise@^8.0.0, promise@^8.1.0:
   dependencies:
     asap "~2.0.6"
 
+prompt@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/prompt/-/prompt-1.2.0.tgz#5d8f1d9011766bac07abde510dbf4338d87b4f02"
+  integrity sha512-iGerYRpRUg5ZyC+FJ/25G5PUKuWAGRjW1uOlhX7Pi3O5YygdK6R+KEaBjRbHSkU5vfS5PZCltSPZdDtUYwRCZA==
+  dependencies:
+    async "~0.9.0"
+    colors "^1.1.2"
+    read "1.0.x"
+    revalidator "0.1.x"
+    winston "2.x"
+
 prompts@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.0.tgz#4aa5de0723a231d1ee9121c40fdf663df73f61d7"
@@ -21395,6 +21513,13 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
+read@1.0.x:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4"
+  integrity sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=
+  dependencies:
+    mute-stream "~0.0.4"
+
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.9, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
@@ -22109,6 +22234,11 @@ reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
+revalidator@0.1.x:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/revalidator/-/revalidator-0.1.8.tgz#fece61bfa0c1b52a206bd6b18198184bdd523a3b"
+  integrity sha1-/s5hv6DBtSoga9axgZgYS91SOjs=
 
 rework-visit@1.0.0:
   version "1.0.0"
@@ -23221,6 +23351,11 @@ stable@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
+
+stack-trace@0.0.x:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+  integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
 
 stack-utils@^2.0.2:
   version "2.0.3"
@@ -24415,6 +24550,24 @@ ts-invariant@^0.9.0:
   integrity sha512-hSeYibh29ULlHkuEfukcoiyTct+s2RzczMLTv4x3NWC/YrBy7x7ps5eYq/b4Y3Sb9/uAlf54+/5CAEMVxPhuQw==
   dependencies:
     tslib "^2.1.0"
+
+ts-node@^10.3.0:
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.3.0.tgz#a797f2ed3ff50c9a5d814ce400437cb0c1c048b4"
+  integrity sha512-RYIy3i8IgpFH45AX4fQHExrT8BxDeKTdC83QFJkNzkvt8uFB6QJ8XMyhynYiKMLxt9a7yuXaDBZNOYS3XjDcYw==
+  dependencies:
+    "@cspotcode/source-map-support" "0.7.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    yn "3.1.1"
 
 ts-pnp@1.2.0, ts-pnp@^1.1.6:
   version "1.2.0"
@@ -26725,6 +26878,18 @@ window-size@^0.2.0:
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.2.0.tgz#b4315bb4214a3d7058ebeee892e13fa24d98b075"
   integrity sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=
 
+winston@2.x:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-2.4.5.tgz#f2e431d56154c4ea765545fc1003bd340c95b59a"
+  integrity sha512-TWoamHt5yYvsMarGlGEQE59SbJHqGsZV8/lwC+iCcGeAe0vUaOh+Lv6SYM17ouzC/a/LB1/hz/7sxFBtlu1l4A==
+  dependencies:
+    async "~1.0.0"
+    colors "1.0.x"
+    cycle "1.0.x"
+    eyes "0.1.x"
+    isstream "0.1.x"
+    stack-trace "0.0.x"
+
 word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
@@ -27351,6 +27516,11 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

## Motivation
https://app.shortcut.com/uma-project/story/2353/write-documentation-for-how-to-manually-reveal-via-etherscan

## Summary
This adds 2 methods for manually revealing. One is through the users signed keys pulled from the voter dapp localstorage. This is by far the easiest as it requires the least work to reveal. 

The second method requires the users backup commit seeds. It also requires the user re-enter the prices which were committed. The backup commit seeds can only be read from a file with this script.

In both cases it requires some technical knowledge to get the required information, run the scripts and execute the manual reveal, so its recommended we use this internally or allow sophisticated users to run.

Both scripts return a json string which can be pasted into etherscans `batchReveal` function on the voting contract. Documentation has been added (but no pictures) to help describe the full process.

## Testing
This has been tested against the kovan voting contract.