### PR TITLE
bug: reconnect works.

### DIFF
--- a/src/common/context/OnboardContext.tsx
+++ b/src/common/context/OnboardContext.tsx
@@ -131,7 +131,7 @@ function connectionReducer(state: OnboardState, action: Action) {
       };
     }
     case RESET_STATE: {
-      return INITIAL_STATE;
+      return { ...INITIAL_STATE, onboard: state.onboard };
     }
     default: {
       throw new Error(`Unsupported action type ${(action as any).type}`);
@@ -153,10 +153,12 @@ const INITIAL_STATE = {
 const connect = async (
   dispatch: OnboardDispatch,
   network: Network | null,
-  subscriptions: Subscriptions
+  subscriptions: Subscriptions,
+  onboard: OnboardApi | null
 ) => {
   try {
-    const onboardInstance = createOnboardInstance(network, subscriptions);
+    const onboardInstance =
+      onboard || createOnboardInstance(network, subscriptions);
 
     await onboardInstance.walletSelect();
     await onboardInstance.walletCheck();

--- a/src/common/hooks/useOnboard.ts
+++ b/src/common/hooks/useOnboard.ts
@@ -108,7 +108,8 @@ export default function useOnboard() {
         },
       };
 
-      connect(dispatch, network, subscriptions);
+      connect(dispatch, network, subscriptions, onboard);
+
       setInitOnboard(false);
     }
   }, [


### PR DESCRIPTION
** Motivation**
Onboard throws a websocket error on reconnecting to the wallet (click connect -> disconnect -> connect, get error).

** Summary **
Pass in the onboard instance in context. Don't set it to null on disconnect, as well as if it exists, don't attempt to recreate it -- just reference it to connect again.

https://app.shortcut.com/uma-project/story/2414/onboard-instance-doesn-t-properly-reset-on-disconnect

Signed-off-by: Tulun <jaykiraly@gmail.com>