### PR TITLE
fix: fix issue where it shows a vote was revealed when not

### DIFF
--- a/src/common/hooks/useOnboard.ts
+++ b/src/common/hooks/useOnboard.ts
@@ -1,7 +1,6 @@
 import { useContext, useState } from "react";
 import { OnboardContext } from "common/context/OnboardContext";
 
-
 export default function useOnboard() {
   const [initOnboard, setInitOnboard] = useState(false);
   const context = useContext(OnboardContext);
@@ -33,11 +32,10 @@ export default function useOnboard() {
     address,
     error,
     isConnected,
-    connect: ()=> connect(dispatch,onboard),
+    connect: () => connect(dispatch, onboard),
     disconnect: () => disconnect(dispatch, onboard),
     initOnboard,
     setInitOnboard,
     notify,
   };
-
 }

--- a/src/common/hooks/useOnboard.ts
+++ b/src/common/hooks/useOnboard.ts
@@ -1,24 +1,6 @@
-import { useContext, useEffect, useState } from "react";
-import { OnboardContext, actions } from "common/context/OnboardContext";
-import { ethers } from "ethers";
-import { Wallet } from "bnc-onboard/dist/src/interfaces";
-import Notify from "bnc-notify";
+import { useContext, useState } from "react";
+import { OnboardContext } from "common/context/OnboardContext";
 
-type ChainId = 1 | 42 | 1337;
-
-const getNetworkName = (chainId: ChainId) => {
-  switch (chainId) {
-    case 1: {
-      return "homestead";
-    }
-    case 42: {
-      return "kovan";
-    }
-    case 1337: {
-      return "test";
-    }
-  }
-};
 
 export default function useOnboard() {
   const [initOnboard, setInitOnboard] = useState(false);
@@ -43,85 +25,6 @@ export default function useOnboard() {
     disconnect,
   } = context;
 
-  // When network changes, reconnect
-  useEffect(() => {
-    if (initOnboard) {
-      // These are optional callbacks to be passed into onboard.
-      const subscriptions = {
-        address: (addr: string | null) => {
-          dispatch({ type: actions.SET_ADDRESS, payload: addr });
-        },
-        network: async (networkId: any) => {
-          if (networkId) {
-            dispatch({
-              type: actions.SET_NETWORK,
-              payload: {
-                chainId: networkId,
-                name: getNetworkName(networkId as ChainId),
-              },
-            });
-          } else {
-            dispatch({
-              type: actions.SET_NETWORK,
-              payload: null,
-            });
-          }
-
-          // Notify.js doesn't work on ganache anyway (see: docs).
-          // So don't bother initializing it on test.
-          if (process.env.REACT_APP_CURRENT_ENV !== "test") {
-            if (networkId) {
-              dispatch({
-                type: actions.SET_NOTIFY,
-                payload: Notify({
-                  dappId: process.env.REACT_APP_PUBLIC_ONBOARD_API_KEY, // [String] The API key created by step one above
-                  networkId, // [Integer] The Ethereum network ID your Dapp uses.
-                  desktopPosition: "topRight",
-                }),
-              });
-            } else {
-              dispatch({
-                type: actions.SET_NOTIFY,
-                payload: null,
-              });
-            }
-          }
-        },
-        wallet: async (wallet: Wallet) => {
-          if (wallet.provider) {
-            const ethersProvider = new ethers.providers.Web3Provider(
-              wallet.provider
-            );
-            dispatch({ type: actions.SET_PROVIDER, payload: ethersProvider });
-            dispatch({
-              type: actions.SET_SIGNER,
-              payload: ethersProvider.getSigner(),
-            });
-            dispatch({
-              type: actions.SET_NETWORK,
-              payload: await ethersProvider.getNetwork(),
-            });
-          } else {
-            dispatch({ type: actions.SET_PROVIDER, payload: null });
-            dispatch({ type: actions.SET_NETWORK, payload: null });
-          }
-        },
-      };
-
-      connect(dispatch, network, subscriptions, onboard);
-
-      setInitOnboard(false);
-    }
-  }, [
-    network,
-    connect,
-    initOnboard,
-    setInitOnboard,
-    dispatch,
-    onboard,
-    disconnect,
-  ]);
-
   return {
     provider,
     onboard,
@@ -130,10 +33,11 @@ export default function useOnboard() {
     address,
     error,
     isConnected,
-    connect,
+    connect: ()=> connect(dispatch,onboard),
     disconnect: () => disconnect(dispatch, onboard),
     initOnboard,
     setInitOnboard,
     notify,
   };
+
 }

--- a/src/common/web3/get/queryCurrentRoundId.ts
+++ b/src/common/web3/get/queryCurrentRoundId.ts
@@ -7,6 +7,6 @@ export const queryCurrentRoundId = async (contract: ethers.Contract) => {
       return roundIdToString;
     }
   } catch (err) {
-    console.log("err", err);
+    console.error("err", err);
   }
 };

--- a/src/common/web3/get/queryGetPendingRequests.ts
+++ b/src/common/web3/get/queryGetPendingRequests.ts
@@ -32,7 +32,7 @@ export const queryGetPendingRequests = async (contract: ethers.Contract) => {
               try {
                 ancData = ethers.utils.toUtf8String(x[2]);
               } catch (err) {
-                console.log("Invalid ancillaryData coding");
+                console.error("Invalid ancillaryData coding");
                 ancData = "Bad anc data encoding.";
               }
             }

--- a/src/features/vote/RevealPhase.tsx
+++ b/src/features/vote/RevealPhase.tsx
@@ -204,7 +204,7 @@ const RevealPhase: FC<Props> = ({
                                 }
                               })
                               .catch((err) => {
-                                console.log("err in snapshot", err);
+                                console.error("err in snapshot", err);
                                 addError(err);
                               });
                           }

--- a/src/features/vote/Vote.tsx
+++ b/src/features/vote/Vote.tsx
@@ -22,7 +22,7 @@ import {
   useVotingContract,
   usePendingRequests,
   useCurrentRoundId,
-  useVotesRevealedEvents,
+  useVotesRevealedEventsRound,
   useEncryptedVotesEvents,
 } from "hooks";
 
@@ -74,7 +74,7 @@ const Vote: FC<Props> = ({
   const {
     data: revealedVotes = [] as VoteRevealed[],
     refetch: refetchVoteRevealedEvents,
-  } = useVotesRevealedEvents(votingContract, votingAddress);
+  } = useVotesRevealedEventsRound(votingContract, votingAddress || hotAddress, roundId);
 
   const signingPK =
     hotAddress && signingKeys[hotAddress]

--- a/src/features/wallet/Wallet.tsx
+++ b/src/features/wallet/Wallet.tsx
@@ -71,8 +71,6 @@ const Wallet: FC<Props> = ({ signingKeys, refetchVoteSummaryData }) => {
   const { data: umaPrice } = useUmaPriceData();
   const { isOpen, open, close, modalRef } = useModal();
   const {
-    initOnboard,
-    setInitOnboard,
     isConnected,
     onboard,
     disconnect,
@@ -80,6 +78,7 @@ const Wallet: FC<Props> = ({ signingKeys, refetchVoteSummaryData }) => {
     address,
     network,
     notify,
+    connect,
   } = useOnboard();
 
   const { addError } = useContext(ErrorContext);
@@ -242,7 +241,7 @@ const Wallet: FC<Props> = ({ signingKeys, refetchVoteSummaryData }) => {
               <Button
                 className="connect-btn"
                 onClick={() => {
-                  if (!initOnboard) setInitOnboard(true);
+                  connect().catch(console.error)
                 }}
                 variant="secondary"
               >

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,6 +4,7 @@ export { default as usePriceRoundEvents } from "./usePriceRoundEvents";
 export { default as useRewardsRetrievedEvents } from "./useRewardsRetrievedEvents";
 export { default as useVotesCommittedEvents } from "./useVotesCommittedEvents";
 export { default as useVotesRevealedEvents } from "./useVotesRevealedEvents";
+export { default as useVotesRevealedEventsRound } from "./useVotesRevealedEventsRound";
 export { default as usePriceRequestAddedEvents } from "./usePriceRequestAddedEvents";
 export { default as useVotingAddress } from "./useVotingAddress";
 export { default as useVotingContract } from "./useVotingContract";

--- a/src/hooks/useVotesRevealedEventsRound.ts
+++ b/src/hooks/useVotesRevealedEventsRound.ts
@@ -7,11 +7,12 @@ import {
 
 export default function useVotesRevealedEvents(
   contract: ethers.Contract | null,
-  address: string | null
+  address: string | null,
+  roundId?: string
 ) {
   return useQuery<VoteRevealed[] | undefined | void>(
-    ["votesRevealedEvents", address],
-    () => queryVotesRevealedEvents(contract, address),
-    { enabled: !!contract && !!address }
+    ["votesRevealedEventsByRound", address, roundId],
+    () => queryVotesRevealedEvents(contract, address, roundId),
+    { enabled: !!contract && !!roundId && !!roundId.length && !!address }
   );
 }

--- a/src/hooks/useVotesRevealedEventsSummary.ts
+++ b/src/hooks/useVotesRevealedEventsSummary.ts
@@ -1,10 +1,8 @@
-import { useContext } from "react";
 import { useQuery } from "react-query";
 import {
   queryVotesRevealedEvents,
   VoteRevealed,
 } from "common/web3/get/queryVotesRevealedEvents";
-import { ErrorContext } from "common/context/ErrorContext";
 import provider from "common/utils/web3/createProvider";
 import createVoidSignerVotingContractInstance from "common/web3/createVoidSignerVotingContractInstance";
 import determineBlockchainNetwork from "common/web3/helpers/determineBlockchainNetwork";
@@ -15,19 +13,9 @@ const contract = createVoidSignerVotingContractInstance(
 );
 
 export default function useVotesRevealedEventsSummary() {
-  const { addError } = useContext(ErrorContext);
-
-  const { data, error, isFetching, refetch } = useQuery<
-    VoteRevealed[] | undefined | void
-  >(
+  return useQuery<VoteRevealed[] | undefined | void>(
     "votesRevealedEventsSummary",
-    () => {
-      return queryVotesRevealedEvents(contract, null)
-        .then((res) => res)
-        .catch((err) => addError(err));
-    },
+    () => queryVotesRevealedEvents(contract),
     { enabled: contract !== null }
   );
-
-  return { data, error, isFetching, refetch };
 }

--- a/src/hooks/useVotingAddress.ts
+++ b/src/hooks/useVotingAddress.ts
@@ -28,8 +28,9 @@ export default function useVotingAddress(
             setVotingAddress(res);
             setHotAddress(address);
           }
-        }).catch((err:Error)=>{
-          console.error('Error getting designated voting address:',err)
+        })
+        .catch((err: Error) => {
+          console.error("Error getting designated voting address:", err);
         });
     } else {
       setVotingAddress(null);


### PR DESCRIPTION
This pr fixes the reveal issue and refactors onboard init to ensure it and notifyjs only happens once on app load. this seems to generally improve performance of the app. 

The reveal bug: this would happen when you first load the page, you would see that you revealed when you hadnt yet.  I believe the main culprit here was sharing react-query caches between other similar calls to fetch revealed events. Some part of the app fetches all reveal events, to show statistics in the details for each vote. If this fills the cache, your vote would be "found" as revealed because all args on the reveal objects were checked *except* the address that voted.  There were some other minor issues cleaned up during this investigation.

refactoring onboard: this started as looking into performance issues with the app. I performed a similar change to the across app, moving onboard init out of react to ensure it only gets instanced once. This seems to have positive impact on the app as it feels slightly more responsive