### PR TITLE
fix: App doesn't crash when on wrong network.

### DIFF
--- a/src/common/utils/web3/createDesignatedVotingContractFactoryInstance.ts
+++ b/src/common/utils/web3/createDesignatedVotingContractFactoryInstance.ts
@@ -19,7 +19,7 @@ export default function createDesignatedVotingContractInstance(
   const network = artifact[networkId];
 
   const contract = new ethers.Contract(
-    network.address,
+    network?.address ?? "",
     DesignatedVotingArtifact.abi,
     signer
   );


### PR DESCRIPTION
Passes in empty string instead.

Prompt is done in MetaMask -- we may want a more in app solution, but that's probably a different ticket.
Signed-off-by: Tulun <jaykiraly@gmail.com>