### PR TITLE
voter-dapp(fix): reduce description max width

### DIFF
--- a/src/features/vote/styled/ActiveRequests.styled.tsx
+++ b/src/features/vote/styled/ActiveRequests.styled.tsx
@@ -49,6 +49,7 @@ export const Description = styled.span`
   color: #818180;
   line-height: 1.57;
   font-size: ${14 / 16}rem;
+  max-width: 40ch;
   span {
     color: #ff4a4a;
     &:hover {


### PR DESCRIPTION
Before:
<img width="1147" alt="CleanShot 2022-01-28 at 12 56 48@2x" src="https://user-images.githubusercontent.com/29527327/151543084-a1fd1305-3968-4537-96c7-224d3462d3ec.png">

After:
<img width="1182" alt="CleanShot 2022-01-28 at 12 57 02@2x" src="https://user-images.githubusercontent.com/29527327/151543120-27f38a2a-92e9-4afa-9be6-74345421ce19.png">



Signed-off-by: Gamaranto <francesco@umaproject.org>