### PR TITLE
voter-dapp(fix): make collect red and bold

### DIFF
--- a/src/features/wallet/styled/Wallet.styled.tsx
+++ b/src/features/wallet/styled/Wallet.styled.tsx
@@ -96,14 +96,14 @@ export const AvailableRewards = styled.div`
 
 export const SmallTitle = styled.p`
   margin: 0 0 12px;
-  opacity: 0.5;
   font-size: 14px;
   font-weight: 400;
-  color: #000;
+  color: rgba(0, 0, 0, 0.5);
   .Wallet-collect {
     text-decoration: underline;
     cursor: pointer;
     color: #ff4a4a;
+    font-weight: 700;
     /* font-size: 0.875rem; */
     margin-left: 4px;
     margin-bottom: 1px;


### PR DESCRIPTION
Before:
<img width="246" alt="CleanShot 2022-01-28 at 13 12 16@2x" src="https://user-images.githubusercontent.com/29527327/151544943-0d58caaa-fe15-4861-a5da-d3f907e754ee.png">

After:
![image](https://user-images.githubusercontent.com/29527327/151544926-7f2edb5b-9323-4551-8355-5be02d5fbf53.png)



Signed-off-by: Gamaranto <francesco@umaproject.org>