### PR TITLE
fix: bump past request number, reduce block range for event queries

### DIFF
--- a/src/common/components/navbar/Navbar.tsx
+++ b/src/common/components/navbar/Navbar.tsx
@@ -126,7 +126,6 @@ const HEADER_LINKS: IHeaderLink[] = [
   {
     key: "Vote",
     component: ({ path }) => {
-      console.log({ path });
       return (
         <UI.NavLink to="/" active={path === "/"}>
           Vote

--- a/src/common/hooks/useVoteData.ts
+++ b/src/common/hooks/useVoteData.ts
@@ -63,7 +63,10 @@ const POLLING_INTERVAL = 60000;
 function useVoteData(account: string | null) {
   const [votingSummaryData, setVotingSummaryData] =
     useState<FormattedPriceRequestRounds>({});
-  const [numToQuery, setNumToQuery] = useState(5);
+  // this query does not discriminate between past and current votes. so if we have 10 current votes,
+  // we wont find any past votes and it will continue to be loading. This used to be 5, then we had 5
+  // active votes and past requests would not load, so this is bumped to 10. 
+  const [numToQuery, setNumToQuery] = useState(10);
 
   // Because apollo caches results of queries, we will poll/refresh this query periodically.
   // We set the poll interval to a very slow 60 seconds for now since the vote states

--- a/src/common/hooks/useVoteData.ts
+++ b/src/common/hooks/useVoteData.ts
@@ -65,7 +65,7 @@ function useVoteData(account: string | null) {
     useState<FormattedPriceRequestRounds>({});
   // this query does not discriminate between past and current votes. so if we have 10 current votes,
   // we wont find any past votes and it will continue to be loading. This used to be 5, then we had 5
-  // active votes and past requests would not load, so this is bumped to 10. 
+  // active votes and past requests would not load, so this is bumped to 10.
   const [numToQuery, setNumToQuery] = useState(10);
 
   // Because apollo caches results of queries, we will poll/refresh this query periodically.

--- a/src/common/utils/events.ts
+++ b/src/common/utils/events.ts
@@ -1,0 +1,114 @@
+// this logic was copied from uma sdk, not added as a dependency because its too large
+import assert from 'assert'
+
+// This state is meant for adjusting a start/end block when querying events. Some apis will fail if the range
+// is too big, so the following functions will adjust range dynamically.
+export type RangeState = {
+  startBlock: number;
+  endBlock: number;
+  maxRange: number;
+  currentRange: number;
+  currentStart: number; // This is the start value you want for your query.
+  currentEnd: number; // this is the end value you want for your query.
+  done: boolean; // Signals we successfully queried the entire range.
+  multiplier?: number; // Multiplier increases or decreases range by this value, depending on success or failure
+};
+
+/**
+ * rangeStart. This starts a new range query and sets defaults for state.  Use this as the first call before starting your queries
+ *
+ * @param {Pick} state
+ * @returns {RangeState}
+ */
+export function rangeStart(
+  state: Pick<RangeState, "startBlock" | "endBlock" | "multiplier"> & { maxRange?: number }
+): RangeState {
+  const { startBlock, endBlock, multiplier = 2 } = state;
+  if (state.maxRange && state.maxRange > 0) {
+    const range = endBlock - startBlock;
+    assert(range > 0, "End block must be higher than start block");
+    const currentRange = Math.min(state.maxRange, range);
+    const currentStart = endBlock - currentRange;
+    const currentEnd = endBlock;
+    return {
+      done: false,
+      startBlock,
+      endBlock,
+      maxRange: state.maxRange,
+      currentRange,
+      currentStart,
+      currentEnd,
+      multiplier,
+    };
+  } else {
+    // the largest range we can have, since this is the users query for start and end
+    const maxRange = endBlock - startBlock;
+    assert(maxRange > 0, "End block must be higher than start block");
+    const currentStart = startBlock;
+    const currentEnd = endBlock;
+    const currentRange = maxRange;
+
+    return {
+      done: false,
+      startBlock,
+      endBlock,
+      maxRange,
+      currentRange,
+      currentStart,
+      currentEnd,
+      multiplier,
+    };
+  }
+}
+/**
+ * rangeSuccessDescending. We have 2 ways of querying events, from oldest to newest, or newest to olde st. Typically we want them in order, from
+ * oldest to newest, but for this particular case we want them newest to oldest, ie descending ( large r timestamp to smaller timestamp).
+ * This function will increase the range between start/end block and return a new start/end to use sin ce by calling this you are signalling
+ * that the last range ended in a successful query.
+ *
+ * @param {RangeState} state
+ * @returns {RangeState}
+ */
+export function rangeSuccessDescending(state: RangeState): RangeState {
+  const { startBlock, currentStart, maxRange, currentRange, multiplier = 2 } = state;
+  // we are done if we succeeded querying where the currentStart matches are initial start block
+  const done = currentStart <= startBlock;
+  // increase range up to max range for every successful query
+  const nextRange = Math.min(Math.ceil(currentRange * multiplier), maxRange);
+  // move our end point to the previously successful start, ie moving from newest to oldest
+  const nextEnd = currentStart;
+  // move our start block to the next range down
+  const nextStart = Math.max(nextEnd - nextRange, startBlock);
+  return {
+    ...state,
+    currentStart: nextStart,
+    currentEnd: nextEnd,
+    currentRange: nextRange,
+    done,
+  };
+}
+/**
+ * rangeFailureDescending. Like the previous function, this will decrease the range between start/end for your query, because you are signalling
+ * that the last query failed. It will also keep the end of your range the same, while moving the star t range up. This is why
+ * its considered descending, it will attempt to move from end to start, rather than start to end.
+ *
+ * @param {RangeState} state
+ * @returns {RangeState}
+ */
+export function rangeFailureDescending(state: RangeState): RangeState {
+  const { startBlock, currentEnd, currentRange, multiplier = 2 } = state;
+  const nextRange = Math.floor(currentRange / multiplier);
+  // this will eventually throw an error if you keep calling this function, which protects us against re-querying a broken api in a loop
+  assert(nextRange > 0, "Range must be above 0");
+  // we stay at the same end block
+  const nextEnd = currentEnd;
+  // move our start block closer to the end block, shrinking the range
+  const nextStart = Math.max(nextEnd - nextRange, startBlock);
+  return {
+    ...state,
+    currentStart: nextStart,
+    currentEnd: nextEnd,
+    currentRange: nextRange,
+  };
+}
+

--- a/src/common/web3/get/queryVotesCommittedEvents.ts
+++ b/src/common/web3/get/queryVotesCommittedEvents.ts
@@ -1,6 +1,7 @@
 import { ethers } from "ethers";
 import { VOTER_CONTRACT_BLOCK } from "common/config";
 import assert from "assert";
+import * as utils from "common/utils/events"
 
 import { VoteEvent } from "../types.web3";
 
@@ -35,25 +36,34 @@ export const queryVotesCommittedEvents = async (
     null
   );
 
-  try {
-    const events = await contract.queryFilter(
-      filter,
-
-      VOTER_CONTRACT_BLOCK
-    );
-    return events.map((el) => {
-      const { args } = el;
-      const datum = {} as VoteEvent;
-      if (args) {
-        datum.address = args[0];
-        datum.roundId = args[1].toString();
-        datum.identifier = ethers.utils.toUtf8String(args[2]);
-        datum.time = args[3].toString();
-      }
-
-      return datum;
-    });
-  } catch (err) {
-    console.log("err", err);
+  let events = []
+  let rangeState = utils.rangeStart({
+    startBlock:VOTER_CONTRACT_BLOCK,
+    endBlock: await contract.provider.getBlockNumber(),
+  })
+  while(!rangeState.done){
+    try{
+      const newEvents = await contract.queryFilter(
+        filter,
+        rangeState.currentStart,
+        rangeState.currentEnd,
+      );
+      rangeState = utils.rangeSuccessDescending(rangeState)
+      events.push(...newEvents)
+    }catch(err){
+      rangeState = utils.rangeFailureDescending(rangeState)
+    }
   }
+  return events.map((el) => {
+    const { args } = el;
+    const datum = {} as VoteEvent;
+    if (args) {
+      datum.address = args[0];
+      datum.roundId = args[1].toString();
+      datum.identifier = ethers.utils.toUtf8String(args[2]);
+      datum.time = args[3].toString();
+    }
+
+    return datum;
+  });
 };

--- a/src/common/web3/get/queryVotesCommittedEvents.ts
+++ b/src/common/web3/get/queryVotesCommittedEvents.ts
@@ -1,7 +1,7 @@
 import { ethers } from "ethers";
 import { VOTER_CONTRACT_BLOCK } from "common/config";
 import assert from "assert";
-import * as utils from "common/utils/events"
+import * as utils from "common/utils/events";
 
 import { VoteEvent } from "../types.web3";
 
@@ -36,22 +36,22 @@ export const queryVotesCommittedEvents = async (
     null
   );
 
-  let events = []
+  let events = [];
   let rangeState = utils.rangeStart({
-    startBlock:VOTER_CONTRACT_BLOCK,
+    startBlock: VOTER_CONTRACT_BLOCK,
     endBlock: await contract.provider.getBlockNumber(),
-  })
-  while(!rangeState.done){
-    try{
+  });
+  while (!rangeState.done) {
+    try {
       const newEvents = await contract.queryFilter(
         filter,
         rangeState.currentStart,
-        rangeState.currentEnd,
+        rangeState.currentEnd
       );
-      rangeState = utils.rangeSuccessDescending(rangeState)
-      events.push(...newEvents)
-    }catch(err){
-      rangeState = utils.rangeFailureDescending(rangeState)
+      rangeState = utils.rangeSuccessDescending(rangeState);
+      events.push(...newEvents);
+    } catch (err) {
+      rangeState = utils.rangeFailureDescending(rangeState);
     }
   }
   return events.map((el) => {

--- a/src/common/web3/get/queryVotesRevealedEvents.ts
+++ b/src/common/web3/get/queryVotesRevealedEvents.ts
@@ -2,7 +2,7 @@ import { ethers } from "ethers";
 import { VoteEvent } from "../types.web3";
 import assert from "assert";
 import { VOTER_CONTRACT_BLOCK } from "common/config";
-import * as utils from "common/utils/events"
+import * as utils from "common/utils/events";
 
 export interface VoteRevealed extends VoteEvent {
   price: string;
@@ -37,22 +37,22 @@ export const queryVotesRevealedEvents = async (
     null,
     numTokens
   );
-  let events = []
+  let events = [];
   let rangeState = utils.rangeStart({
-    startBlock:VOTER_CONTRACT_BLOCK,
+    startBlock: VOTER_CONTRACT_BLOCK,
     endBlock: await contract.provider.getBlockNumber(),
-  })
-  while(!rangeState.done){
-    try{
+  });
+  while (!rangeState.done) {
+    try {
       const newEvents = await contract.queryFilter(
         filter,
         rangeState.currentStart,
-        rangeState.currentEnd,
+        rangeState.currentEnd
       );
-      rangeState = utils.rangeSuccessDescending(rangeState)
-      events.push(...newEvents)
-    }catch(err){
-      rangeState = utils.rangeFailureDescending(rangeState)
+      rangeState = utils.rangeSuccessDescending(rangeState);
+      events.push(...newEvents);
+    } catch (err) {
+      rangeState = utils.rangeFailureDescending(rangeState);
     }
   }
   return events.map((el) => {


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

## Motivation
Event errors were showing up in console requesting too many events. Also past requests would not ever load during this vote with 5 active votes.

```
err Error: processing response error (body="{\"jsonrpc\":\"2.0\",\"id\":52,\"error\":{\"code\":-32005,\"message\":\"query returned 
more than 10000 results\"}}", error={"code":-32005}, requestBody="{\"method\":\"eth_getLogs\",\"params\":
[{\"fromBlock\":\"0xb539e7\",\"toBlock\":\"latest\",\"address\":\"0x8b1631ab830d11531ae83725fda4d86012eccd77\",
```

## Solution
Code was copied from the sdk which retries event queries and adjust block range dynamically to prevent event error. Also doubled the past queried events because it was set to 5, and 5 active votes are going on, so our query only included active requests, leaving the pending array empty. 